### PR TITLE
Support for custom defined options in wp-config.php that override options in database

### DIFF
--- a/src/class-ss-options.php
+++ b/src/class-ss-options.php
@@ -82,11 +82,24 @@ class Options {
 
 	/**
 	 * Returns a value of the option identified by $name
+     *
+     * Also checks if option exists in wp-config.php, and uses it to override the database value
+     *
+     * Fore example:
+     * SIMPLY_STATIC_TEMP_FILES_DIR     in wp-config.php overrides temp_files_dir loaded from database
+     * SIMPLY_STATIC_DELIVERY_METHOD    in wp-config.php overrides delivery_method loaded from database
+     *
 	 * @param string $name The option name
 	 * @return mixed|null
 	 */
-	public function get( $name ) {
-		return array_key_exists( $name, $this->options ) ? $this->options[ $name ] : null;
+	public function get( $name = '' ) {
+        return array_key_exists( $name, $this->options ) ?
+            (
+                defined('SIMPLY_STATIC_' . strtoupper( $name ) ) ?
+                constant('SIMPLY_STATIC_' . strtoupper( $name ) ) :
+                $this->options[ $name ]
+            )
+            : null;
 	}
 
 	/**

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -256,7 +256,7 @@ class Plugin {
 			Util::delete_debug_log();
 			Util::debug_log( "Received request to start generating a static archive" );
 
-			if ( DISABLE_WP_CRON !== true ) {
+			if ( ! defined( 'DISABLE_WP_CRON' ) || DISABLE_WP_CRON !== true ) {
 				if ( ! wp_next_scheduled( 'simply_static_site_export_cron' ) ) {
 					wp_schedule_single_event( time(), 'simply_static_site_export_cron' );
 				}


### PR DESCRIPTION
**The issue**

A user has a site in production with some database. Everything works fine and he can generate static files. He now wants to develop more features on his local machine, so he pulls the code and makes a dump from production DB, and imports it to his local machine. 

When he tries to generate static files, he notices that paths are different on his local machine, e.g. instead of _/var/www/html_ he has _/user/john/sites/html_. So now he needs to update the settings in the database, not a problem, just go to the settings page and make some the changes.

But what if he needs later to make another dump from production? He would need to update the settings again. If he does this often, it can be very annoying. Also, the other problem would be if he needs to apply his local dump to production, or even when he shares the dump with some other people, or even using the same database in different environments, or when multiple users connect to the same remote database or even when using cross-environments sync database plugins.

**The solution**

Is to have his own set of settings in his local wp-config.php file. This way he can set his local specific settings and use the same dump from production over and over without even checking the settings ever again. Even If he wants to apply his local dump to production, he will not affect the production settings.

This PR uses the original Options class with an additional check for wp-config constants. For example, if there is a constant named: "**SIMPLY_STATIC_TEMP_FILES_DIR**" in wp-config.php it will override option "**temp_files_dir**" on the fly without touching the database.

Constants are in format **"SIMPLY_STATIC_" + UPPERCASE(<original_option_name>)**

Thanks!

