### PR TITLE
Add 'srcset' to 'source'

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -54,7 +54,7 @@ class Url_Extractor {
 		'embed'        => array( 'src', 'code', 'pluginspage' ),
 		'event-source' => array( 'src' ),
 		'html'         => array( 'manifest', 'background', 'xmlns' ),
-		'source'       => array( 'src' ),
+		'source'       => array( 'src', 'srcset' ),
 		'video'        => array( 'src', 'poster' ),
 
 		'bgsound'      => array( 'src' ),


### PR DESCRIPTION
Add 'srcset' to 'source' to export also .avif and .webp files in `<picture>` tag like:

```html
<picture>
   <source srcset="image.avif" type="image/avif">
   <source srcset="image.webp" type="image/webp">
   <img src="image.jpg" alt="AVIF example with WebP and JPEG fallback">
</picture>
```