### PR TITLE
Bugfix usage of php constant

### DIFF
--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -267,7 +267,7 @@ class Plugin {
 			Util::delete_debug_log();
 			Util::debug_log( "Received request to start generating a static archive" );
 
-			if ( 'on' === $this->options->get( 'use_cron' ) && ( ! defined( 'DISABLE_WP_CRON' ) || 'DISABLE_WP_CRON' !== true ) ) {
+			if ( 'on' === $this->options->get( 'use_cron' ) && ( ! defined( 'DISABLE_WP_CRON' ) || DISABLE_WP_CRON !== true ) ) {
 				if ( ! wp_next_scheduled( 'simply_static_site_export_cron' ) ) {
 					wp_schedule_single_event( time(), 'simply_static_site_export_cron' );
 				}


### PR DESCRIPTION
The comparison 'DISABLE_WP_CRON' !== true is always true. 
Should be DISABLE_WP_CRON !== true