### PR TITLE
Add pages_status index to ping response

### DIFF
--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -294,6 +294,7 @@ class Plugin {
 		wp_send_json( array(
 			'action' => $action,
 			'activity_log_html' => $activity_log_html,
+			'pages_status' => $this->options->get( 'pages_status' ),
 			'done' => $done // $done
 		) );
 	}

--- a/src/class-ss-upgrade-handler.php
+++ b/src/class-ss-upgrade-handler.php
@@ -67,6 +67,7 @@ class Upgrade_Handler {
 			'relative_path'           => '',
 			'destination_url_type'    => 'relative',
 			'archive_status_messages' => array(),
+			'pages_status' => array(),
 			'archive_name'            => null,
 			'archive_start_time'      => null,
 			'archive_end_time'        => null,

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -55,6 +55,7 @@ class Fetch_Urls_Task extends Task {
 
 		while ( $static_page = array_shift( $static_pages ) ) {
 			Util::debug_log( "URL: " . $static_page->url );
+			$this->save_pages_status( count($static_pages)+1, intval($total_pages));
 
 			$excludable = $this->find_excludable( $static_page );
 			if ( $excludable !== false ) {

--- a/src/tasks/class-ss-task.php
+++ b/src/tasks/class-ss-task.php
@@ -50,6 +50,15 @@ abstract class Task {
 			->save();
 	}
 
+	protected function save_pages_status( $pages_remaining, $pages_total ) {
+		$task_name = $key ?: static::$task_name;
+		Util::debug_log( '[PAGES STATUS] Remaining:' . $pages_remaining . '; Total: ' . $pages_total );
+
+		$this->options
+			->set( 'pages_status', array("remaining" => $pages_remaining, "total" => $pages_total) )
+			->save();
+	}
+
 	/*
 	* Override this method to perform the task action.
 	* @return boolean|WP_Error true if done, false if not done, WP_Error if error


### PR DESCRIPTION
Hi,
I'm using your plugin and I'm really enjoying it.
So the main ideia of this pull request it's to add a "pages_status" index to the ping response. This new index will give us the remaining and total pages in real time.
Screenshot:
![Captura de ecrã 2022-10-11, às 17 07 53](https://user-images.githubusercontent.com/49269723/195143703-a06e4d35-b2a9-4365-a8c9-61775bfb8905.png)