### PR TITLE
#63 - Replacing URLs in Script innerText (js code)

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -355,6 +355,7 @@ class Url_Extractor {
 				try {
 					$updated_script     = $this->extract_and_replace_urls_in_script( $tag->innerhtmlKeep );
 					$tag->innerhtmlKeep = $updated_script;
+                    $this->extract_and_replace_urls_in_script_inner_text( $tag );
 				} catch ( Exception $e ) {
 					// If not skip the result.
 					continue;
@@ -425,6 +426,17 @@ class Url_Extractor {
 
 		return $text;
 	}
+
+    /**
+     * @param \ $tag
+     * @return array|string|string[]|null
+     */
+    private function extract_and_replace_urls_in_script_inner_text( $tag ) {
+
+        $tag->innerText = preg_replace( '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', $this->options->get_destination_url(), html_entity_decode( $tag->innerText ) );
+
+        return $tag;
+    }
 
 	/**
 	 * callback function for preg_replace in extract_and_replace_urls_in_css

--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -433,7 +433,25 @@ class Url_Extractor {
      */
     private function extract_and_replace_urls_in_script_inner_text( $tag ) {
 
-        $tag->innerText = preg_replace( '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', $this->options->get_destination_url(), html_entity_decode( $tag->innerText ) );
+        $regex = '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i';
+
+        switch( $this->options->get( 'destination_url_type' ) ) {
+            case 'absolute':
+                $convert_to = $this->options->get_destination_url();
+                break;
+            case 'relative':
+                // Adding \/? before end of regex pattern to convert url.com/ & url.com to relative path, ex. /path/.
+                $regex = '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '\/?/i';
+                $convert_to = $this->options->get( 'relative_path' );
+                break;
+            default:
+                // Offline mode.
+                // Adding \/? before end of regex pattern to convert url.com/ & url.com to relative path, ex. /path/.
+                $regex = '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '\/?/i';
+                $convert_to = '/';
+        }
+
+        $tag->innerText = preg_replace( $regex, $convert_to, html_entity_decode( $tag->innerText ) );
 
         return $tag;
     }


### PR DESCRIPTION
### Which Issue is related to this?

Closes #63 

### Describe what was done

Replacing all URLs inside of the innerText of every script tag. This makes sure that all JavaScript code that contains the origin URL is replaced to work with static files.

### How to test

1. Add a script inside of your site (with help of other plugins or similar)
2. Inside of such script, add the URL in a variable such as `var url = 'YOUR_ORIGIN_URL';`
3. Generate static site
4. Check if `var url` has the correct URL