### PR TITLE
fix: Additional dir paths wrong

### DIFF
--- a/src/tasks/class-ss-setup-task.php
+++ b/src/tasks/class-ss-setup-task.php
@@ -151,6 +151,9 @@ class Setup_Task extends Task {
 		} elseif ( stripos( $path, get_home_path() ) === 0 ) {
 			$url = str_replace( untrailingslashit( get_home_path() ), Util::origin_url(), $path );
 		}
+
+		// Replace backslashes with forward slashes due to windows paths
+		$url = str_replace('\\', '/', $url);
 		return $url;
 	}
 

--- a/src/tasks/class-ss-transfer-files-locally-task.php
+++ b/src/tasks/class-ss-transfer-files-locally-task.php
@@ -62,7 +62,9 @@ class Transfer_Files_Locally_Task extends Task {
 	public function copy_static_files( $destination_dir ) {
 		$batch_size = apply_filters( 'simply_static_copy_files_batch_size', 50 );
 
-		$archive_dir        = $this->options->get_archive_dir();
+		$archive_dir        = untrailingslashit($this->options->get_archive_dir());
+		$destination_dir_safe    = untrailingslashit($destination_dir);
+		
 		$archive_start_time = $this->options->get( 'archive_start_time' );
 
 		// TODO: also check for recent modification time
@@ -83,15 +85,15 @@ class Transfer_Files_Locally_Task extends Task {
 
 		while ( $static_page = array_shift( $static_pages ) ) {
 			$path_info  = Util::url_path_info( $static_page->file_path );
-			$path       = $destination_dir . $path_info['dirname'];
+			$path       = $destination_dir_safe . $path_info['dirname'];
 			$create_dir = wp_mkdir_p( $path );
 			if ( $create_dir === false ) {
-				Util::debug_log( "Cannot create directory: " . $destination_dir . $path_info['dirname'] );
+				Util::debug_log( "Cannot create directory: " . $destination_dir_safe . $path_info['dirname'] );
 				$static_page->set_error_message( 'Unable to create destination directory' );
 			} else {
 				chmod( $path, 0755 );
 				$origin_file_path      = $archive_dir . $static_page->file_path;
-				$destination_file_path = $destination_dir . $static_page->file_path;
+				$destination_file_path = $destination_dir_safe . $static_page->file_path;
 
 				// check that destination file doesn't exist OR exists but is writeable
 				if ( ! file_exists( $destination_file_path ) || is_writable( $destination_file_path ) ) {


### PR DESCRIPTION
Fixed issues with backslashes in path and extra trailing slashes that doubled up when paths were merged causing directory not found errors

Closes #70