### PR TITLE
#62 - Auto-Including Sitemaps for popular plugins

### DIFF
--- a/simply-static.php
+++ b/simply-static.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Simply Static
  * Plugin URI:        https://patrickposner.dev
  * Description:       A static site generator to create fast and secure static versions of your WordPress website.
- * Version:           2.2.1.1
+ * Version:           2.2.2.0
  * Author:            Patrick Posner
  * Author URI:        https://patrickposner.dev
  * License:           GPL-2.0+

--- a/src/class-integrations.php
+++ b/src/class-integrations.php
@@ -27,6 +27,7 @@ class Integrations {
            'yoast' => Yoast_Integration::class,
            'rank-math' => Rank_Math_Integration::class,
            'aio-seo'   => AIO_SEO_Integration::class,
+           'seopress'  => SEOPress_Integration::class,
        ] );
     }
 
@@ -36,5 +37,6 @@ class Integrations {
         require_once $path . 'class-yoast-integration.php';
         require_once $path . 'class-rank-math-integration.php';
         require_once $path . 'class-aio-seo-integration.php';
+        require_once $path . 'class-seopress-integration.php';
     }
 }

--- a/src/class-integrations.php
+++ b/src/class-integrations.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Simply_Static;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Integrations {
+
+    /**
+     * @return void
+     */
+    public function load() {
+        $this->includes();
+        $integrations = $this->get_integrations();
+
+        foreach ( $integrations as $integration ) {
+            $object = new $integration();
+            $object->load();
+        }
+    }
+
+    public function get_integrations() {
+       return apply_filters( 'simply_static_integrations', [
+           'yoast' => Yoast_Integration::class
+       ] );
+    }
+
+    public function includes() {
+        $path = plugin_dir_path( dirname( __FILE__ ) ) . 'src/integrations/';
+        require_once $path . 'class-integration.php';
+        require_once $path . 'class-yoast-integration.php';
+    }
+}

--- a/src/class-integrations.php
+++ b/src/class-integrations.php
@@ -24,7 +24,8 @@ class Integrations {
 
     public function get_integrations() {
        return apply_filters( 'simply_static_integrations', [
-           'yoast' => Yoast_Integration::class
+           'yoast' => Yoast_Integration::class,
+           'rank-math' => Rank_Math_Integration::class
        ] );
     }
 
@@ -32,5 +33,6 @@ class Integrations {
         $path = plugin_dir_path( dirname( __FILE__ ) ) . 'src/integrations/';
         require_once $path . 'class-integration.php';
         require_once $path . 'class-yoast-integration.php';
+        require_once $path . 'class-rank-math-integration.php';
     }
 }

--- a/src/class-integrations.php
+++ b/src/class-integrations.php
@@ -25,7 +25,8 @@ class Integrations {
     public function get_integrations() {
        return apply_filters( 'simply_static_integrations', [
            'yoast' => Yoast_Integration::class,
-           'rank-math' => Rank_Math_Integration::class
+           'rank-math' => Rank_Math_Integration::class,
+           'aio-seo'   => AIO_SEO_Integration::class,
        ] );
     }
 
@@ -34,5 +35,6 @@ class Integrations {
         require_once $path . 'class-integration.php';
         require_once $path . 'class-yoast-integration.php';
         require_once $path . 'class-rank-math-integration.php';
+        require_once $path . 'class-aio-seo-integration.php';
     }
 }

--- a/src/class-page-handlers.php
+++ b/src/class-page-handlers.php
@@ -20,10 +20,14 @@ class Page_Handlers {
         add_action( 'init', [ $this, 'run_page_handlers_from_request' ], 1 );
     }
 
+    /**
+     * Includes
+     *
+     * @return void
+     */
     public function includes() {
         $path = plugin_dir_path( dirname( __FILE__ ) ) . 'src/handlers/';
         require_once $path . 'class-ss-page-handler.php';
-        require_once $path . 'class-ss-yoast-sitemap-handler.php';
     }
 
     /**

--- a/src/class-page-handlers.php
+++ b/src/class-page-handlers.php
@@ -16,7 +16,14 @@ class Page_Handlers {
      * Constructor.
      */
     public function __construct() {
+        $this->includes();
         add_action( 'init', [ $this, 'run_page_handlers_from_request' ], 1 );
+    }
+
+    public function includes() {
+        $path = plugin_dir_path( dirname( __FILE__ ) ) . 'src/handlers/';
+        require_once $path . 'class-ss-page-handler.php';
+        require_once $path . 'class-ss-yoast-sitemap-handler.php';
     }
 
     /**

--- a/src/class-page-handlers.php
+++ b/src/class-page-handlers.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Simply_Static;
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Page Handlers.
+ */
+class Page_Handlers {
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'init', [ $this, 'run_page_handlers_from_request' ], 1 );
+    }
+
+    /**
+     * Check if we are currently in a Static Page Request.
+     * This means that we are retrieving the page to create a static one.
+     *
+     * @return bool
+     */
+    protected function is_static_page_request() {
+        return isset( $_GET['simply_static_page'] ) && absint( $_GET['simply_static_page'] ) > 0;
+    }
+
+    /**
+     * Get Static Page.
+     *
+     * @return \Simply_Static\Page|null
+     */
+    public function get_static_page() {
+        return Page::query()->find_by( 'id', absint( $_GET['simply_static_page'] ) );
+    }
+
+    /**
+     * Get a Page Handler and run hooks.
+     *
+     * @return void
+     */
+    public function run_page_handlers_from_request() {
+        if ( ! $this->is_static_page_request() ) {
+            return;
+        }
+
+        $page = $this->get_static_page();
+
+        $handler = $page->get_handler();
+
+        $handler->run_hooks();
+    }
+}

--- a/src/class-ss-options.php
+++ b/src/class-ss-options.php
@@ -96,7 +96,7 @@ class Options {
             (
                 defined('SIMPLY_STATIC_' . strtoupper( $name ) ) ?
                 constant('SIMPLY_STATIC_' . strtoupper( $name ) ) :
-                $this->options[ $name ]
+                apply_filters( 'ss_get_option_' . strtolower( $name ), $this->options[ $name ], $this )
             )
             : null;
 	}

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -15,7 +15,7 @@ class Plugin {
 	 * Plugin version
 	 * @var string
 	 */
-	const VERSION = '2.2.1.1';
+	const VERSION = '2.2.2.0';
 
 	/**
 	 * The slug of the plugin; used in actions, filters, i18n, table names, etc.
@@ -52,6 +52,11 @@ class Plugin {
 	 * @var string
 	 */
 	protected $current_page = '';
+
+    /**
+     * @var null|\Simply_Static\Page_Handlers
+     */
+    protected $page_handlers = null;
 
 	/**
 	 * Disable usage of "new"
@@ -117,6 +122,7 @@ class Plugin {
 			self::$instance->options              = Options::instance();
 			self::$instance->view                 = new View();
 			self::$instance->archive_creation_job = new Archive_Creation_Job();
+            self::$instance->page_handlers        = new Page_Handlers();
 
 			$page                         = isset( $_GET['page'] ) ? $_GET['page'] : '';
 			self::$instance->current_page = $page;
@@ -172,6 +178,7 @@ class Plugin {
 		require_once $path . 'src/class-ss-sql-permissions.php';
 		require_once $path . 'src/class-ss-upgrade-handler.php';
 		require_once $path . 'src/class-ss-util.php';
+        require_once $path . 'src/class-page-handlers.php';
 	}
 
 	/**

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -128,6 +128,8 @@ class Plugin {
 			self::$instance->current_page = $page;
 
 			Upgrade_Handler::run();
+            $integrations = new Integrations();
+            $integrations->load();
 
 			// Exclude pages if not set.
 			$urls_to_exclude = self::$instance->options->get( 'urls_to_exclude' );
@@ -179,6 +181,7 @@ class Plugin {
 		require_once $path . 'src/class-ss-upgrade-handler.php';
 		require_once $path . 'src/class-ss-util.php';
         require_once $path . 'src/class-page-handlers.php';
+        require_once $path . 'src/class-integrations.php';
 	}
 
 	/**

--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -66,7 +66,7 @@ class Url_Fetcher {
 	/**
 	 * Fetch the URL and return a \WP_Error if we get one, otherwise a Response class.
 	 *
-	 * @param Simply_Static\Page $static_page URL to fetch
+	 * @param \Simply_Static\Page $static_page URL to fetch
 	 *
 	 * @return boolean                        Was the fetch successful?
 	 */
@@ -137,6 +137,7 @@ class Url_Fetcher {
 
 				Util::debug_log( "Renaming temp file from " . $temp_filename . " to " . $file_path );
 				rename( $temp_filename, $file_path );
+                $static_page->get_handler()->after_file_fetch( $this->archive_dir );
 			} else {
 				Util::debug_log( "We weren't able to establish a filename; deleting temp file" );
 				unlink( $temp_filename );

--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -92,6 +92,7 @@ class Url_Fetcher {
 		$temp_filename = wp_tempnam();
 
 		Util::debug_log( "Fetching URL and saving it to: " . $temp_filename );
+        $url = $static_page->get_handler()->prepare_url( $url );
 		$response = self::remote_get( $url, $temp_filename );
 
 		$filesize = file_exists( $temp_filename ) ? filesize( $temp_filename ) : 0;

--- a/src/handlers/class-ss-page-handler.php
+++ b/src/handlers/class-ss-page-handler.php
@@ -38,6 +38,15 @@ class Page_Handler {
     }
 
     /**
+     * Get Options Instance.
+     *
+     * @return \Simply_Static\Options|null
+     */
+    public function get_options() {
+        return Options::instance();
+    }
+
+    /**
      * Run hooks on page request.
      *
      * Useful in case a type of page requires different hooks to be ran before the static page is generated.

--- a/src/handlers/class-ss-page-handler.php
+++ b/src/handlers/class-ss-page-handler.php
@@ -54,4 +54,6 @@ class Page_Handler {
      * @return void
      */
     public function run_hooks() {}
+
+    public function after_file_fetch( $archive_dir ) {}
 }

--- a/src/handlers/class-ss-page-handler.php
+++ b/src/handlers/class-ss-page-handler.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Simply_Static;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Page_Handler {
+
+    /**
+     * Page.
+     * @var Page|null
+     */
+    protected $page = null;
+
+    /**
+     * Constructor method.
+     *
+     * @param Page $page
+     */
+    public function __construct( Page $page ) {
+        $this->page = $page;
+    }
+
+    /**
+     * Add query arguments in case it needs it.
+     *
+     * This way we know which page we are fetching in case we need a handler to run actions/filters.
+     *
+     * @param $url
+     * @return mixed
+     */
+    public function prepare_url( $url ) {
+        $url = add_query_arg( 'simply_static_page', $this->page->id, $url );
+        return $url;
+    }
+
+    /**
+     * Run hooks on page request.
+     *
+     * Useful in case a type of page requires different hooks to be ran before the static page is generated.
+     *
+     * @return void
+     */
+    public function run_hooks() {}
+}

--- a/src/handlers/class-ss-page-handler.php
+++ b/src/handlers/class-ss-page-handler.php
@@ -34,6 +34,7 @@ class Page_Handler {
      */
     public function prepare_url( $url ) {
         $url = add_query_arg( 'simply_static_page', $this->page->id, $url );
+        Util::debug_log( 'URL Prepared:' . $url );
         return $url;
     }
 
@@ -55,5 +56,5 @@ class Page_Handler {
      */
     public function run_hooks() {}
 
-    public function after_file_fetch( $archive_dir ) {}
+    public function after_file_fetch( $destination_dir ) {}
 }

--- a/src/handlers/class-ss-rank-math-sitemap-handler.php
+++ b/src/handlers/class-ss-rank-math-sitemap-handler.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Simply_Static;
+
+use RankMath\Helper;
+use RankMath\Traits\Hooker;
+
+class Rank_Math_Sitemap_Handler extends Page_Handler {
+
+    use Hooker;
+
+    /**
+     * Run hooks on page request.
+     *
+     * Useful in case a type of page requires different hooks to be ran before the static page is generated.
+     *
+     * @return void
+     */
+    public function run_hooks() {
+        // Filter XSL
+        foreach ( Helper::get_accessible_taxonomies() as $taxonomy ) {
+            if ('post_format' === $taxonomy->name) {
+                continue;
+            }
+            \add_filter( 'rank_math/sitemap/' . $taxonomy->name . '_stylesheet_url', [ $this, 'stylesheet_url' ] );
+        }
+
+        foreach ( Helper::get_accessible_post_types() as $post_type ) {
+            $object = get_post_type_object($post_type);
+            \add_filter( 'rank_math/sitemap/' . $object->name . '_stylesheet_url', [ $this, 'stylesheet_url' ] );
+        }
+        // Main: 1_stylesheel_url
+        \add_filter( 'rank_math/sitemap/1_stylesheet_url', [ $this, 'stylesheet_url' ] );
+        \add_filter( 'rank_math/sitemap/enable_caching', '__return_false' );
+    }
+
+    /**
+     * Get Stylesheet URL for XSL.
+     *
+     * @param $xsl_string
+     * @return string
+     */
+    public function stylesheet_url( $xsl_string ) {
+        // Using Origin URL to make sure the URL gets swapped correctly with destination url.
+        return '<?xml-stylesheet type="text/xsl" href="' . trailingslashit( Util::origin_url() ) . 'main-sitemap.xsl' . '"?>';
+    }
+
+    /**
+     * @param $destination_dir
+     * @return void
+     */
+    public function after_file_fetch( $destination_dir ) {
+        $destination_path = Util::combine_path( $destination_dir, '/main-sitemap.xsl' );
+
+        if ( file_exists( $destination_path ) ) {
+            return;
+        }
+
+        Util::debug_log( "Getting content for  main-sitemap.xsl" );
+        ob_start();
+        $this->generate_xsl();
+        $xsl_content = ob_get_clean();
+        $temp_filename = wp_tempnam();
+        file_put_contents( $temp_filename, $xsl_content );
+        $rename = rename( $temp_filename, $destination_path );
+
+        if ( $rename === false ) {
+            Util::debug_log( "Cannot create " . $destination_path );
+        } else {
+            Util::debug_log( "Created " . $destination_path );
+        }
+    }
+
+    /**
+     * Generate XSL
+     *
+     * Code copied from RankMath \RankMath\Sitemap\Stylesheet class.
+     * @see \RankMath\Sitemap\Stylesheet
+     *
+     * @return void
+     */
+    public function generate_xsl() {
+        /* translators: 1. separator, 2. blogname */
+        $title = sprintf( __( 'XML Sitemap %1$s %2$s', 'rank-math' ), '-', get_bloginfo( 'name', 'display' ) );
+
+        /* translators: 1. separator, 2. blogname */
+        $kml_title = sprintf( __( 'Locations Sitemap %1$s %2$s', 'rank-math' ), '-', get_bloginfo( 'name', 'display' ) );
+
+        require_once RANK_MATH_PATH . 'includes/modules/sitemap/sitemap-xsl.php';
+    }
+}

--- a/src/handlers/class-ss-yoast-sitemap-handler.php
+++ b/src/handlers/class-ss-yoast-sitemap-handler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Simply_Static;
+
+class Yoast_Sitemap_Handler extends Page_Handler {
+
+    /**
+     * Run hooks on page request.
+     *
+     * Useful in case a type of page requires different hooks to be ran before the static page is generated.
+     *
+     * @return void
+     */
+    public function run_hooks() {
+        // Filter XSL
+        add_filter( 'wpseo_stylesheet_url', [ $this, 'stylesheet_url' ] );
+    }
+
+    /**
+     * Get Stylesheet URL for XSL.
+     *
+     * @param $xsl_string
+     * @return string
+     */
+    public function stylesheet_url( $xsl_string ) {
+        return '<?xml-stylesheet type="text/xsl" href="' . esc_url( trailingslashit( $this->get_options()->get_destination_url() ) . 'main-sitemap.xsl' ) . '"?>';
+    }
+
+}

--- a/src/handlers/class-ss-yoast-sitemap-handler.php
+++ b/src/handlers/class-ss-yoast-sitemap-handler.php
@@ -23,7 +23,26 @@ class Yoast_Sitemap_Handler extends Page_Handler {
      * @return string
      */
     public function stylesheet_url( $xsl_string ) {
-        return '<?xml-stylesheet type="text/xsl" href="' . esc_url( trailingslashit( $this->get_options()->get_destination_url() ) . 'main-sitemap.xsl' ) . '"?>';
+        return '<?xml-stylesheet type="text/xsl" href="' . trailingslashit( $this->get_options()->get_destination_url() ) . 'main-sitemap.xsl' . '"?>';
     }
 
+    /**
+     * @param $destination_dir
+     * @return void
+     */
+    public function after_file_fetch( $destination_dir ) {
+
+        $xsl_path = dirname( WPSEO_FILE ) . '/css/main-sitemap.xsl';
+        $destination_path = Util::combine_path( $destination_dir, '/main-sitemap.xsl' );
+        if ( file_exists( $destination_path ) ) {
+            return;
+        }
+        $copy = copy( $xsl_path, $destination_path );
+        if ( $copy === false ) {
+            Util::debug_log( "Cannot copy " . $xsl_path . " to " . $destination_path );
+        } else {
+
+            Util::debug_log( "Copied " . $xsl_path . " to " . $destination_path );
+        }
+    }
 }

--- a/src/handlers/class-ss-yoast-sitemap-handler.php
+++ b/src/handlers/class-ss-yoast-sitemap-handler.php
@@ -23,7 +23,8 @@ class Yoast_Sitemap_Handler extends Page_Handler {
      * @return string
      */
     public function stylesheet_url( $xsl_string ) {
-        return '<?xml-stylesheet type="text/xsl" href="' . trailingslashit( $this->get_options()->get_destination_url() ) . 'main-sitemap.xsl' . '"?>';
+        // Using Origin URL to make sure the URL gets swapped correctly with destination url.
+        return '<?xml-stylesheet type="text/xsl" href="' . trailingslashit( Util::origin_url() ) . 'main-sitemap.xsl' . '"?>';
     }
 
     /**

--- a/src/integrations/class-aio-seo-integration.php
+++ b/src/integrations/class-aio-seo-integration.php
@@ -23,9 +23,6 @@ class AIO_SEO_Integration extends Integration {
         if ( function_exists( 'aioseo' ) ) {
             aioseo()->sitemap->type = 'general';
             $post_types  = aioseo()->sitemap->helpers->includedPostTypes();
-            if ( ! $post_types ) {
-                Util::debug_log( 'No post types for sitemap.' );
-            }
             foreach ( $post_types as $post_type ) {
                 $post_type_url = home_url( $post_type . '-sitemap.xml' );
                 $this->register_sitemap_page( $post_type_url );

--- a/src/integrations/class-integration.php
+++ b/src/integrations/class-integration.php
@@ -55,4 +55,14 @@ abstract class Integration {
      * @return void
      */
     public function run() {}
+
+    /**
+     * Include File.
+     *
+     * @param $path
+     * @return void
+     */
+    public function include_file( $path ) {
+       require_once trailingslashit( SIMPLY_STATIC_PATH ) . 'src/' . $path;
+    }
 }

--- a/src/integrations/class-integration.php
+++ b/src/integrations/class-integration.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Simply_Static;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+abstract class Integration {
+
+    /**
+     * A string ID of integration.
+     *
+     * @var string
+     */
+    protected $id = '';
+
+    /**
+     * Load the integration.
+     *
+     * @return void
+     */
+    public function load() {
+        if ( ! $this->is_enabled() ) {
+            return;
+        }
+
+        $this->run();
+    }
+
+
+    /**
+     * Check if such Integration is enabled
+     *
+     * @return mixed|null
+     */
+    public function is_enabled() {
+        return apply_filters( 'simply_static_integration_' . $this->id . 'enabled', $this->can_run() );
+    }
+
+    /**
+     * A Check if this integration can run.
+     * Example: Check if a plugin is activated in DB or a class exists.
+     *
+     * @return boolean
+     */
+    public function can_run() {
+        return true;
+    }
+
+    /**
+     * Run the integration.
+     *
+     * @return void
+     */
+    public function run() {}
+}

--- a/src/integrations/class-rank-math-integration.php
+++ b/src/integrations/class-rank-math-integration.php
@@ -16,7 +16,7 @@ class Rank_Math_Integration extends Integration {
     public function run() {
         add_action( 'ss_after_setup_task', [ $this, 'register_sitemap_page' ] );
 
-        $this->include_file( 'handlers/class-rank-math-handler.php' );
+        $this->include_file( 'handlers/class-ss-rank-math-sitemap-handler.php' );
     }
 
     public function register_sitemap_page() {

--- a/src/integrations/class-rank-math-integration.php
+++ b/src/integrations/class-rank-math-integration.php
@@ -2,28 +2,35 @@
 
 namespace Simply_Static;
 
-class Yoast_Integration extends Integration {
+use RankMath\Sitemap\Router;
 
-    protected $id = 'yoast';
+class Rank_Math_Integration extends Integration {
 
+    protected $id = 'rank-math';
+
+    /**
+     * Run the integration.
+     *
+     * @return void
+     */
     public function run() {
-         add_action( 'ss_after_setup_task', [ $this, 'register_sitemap_page' ] );
+        add_action( 'ss_after_setup_task', [ $this, 'register_sitemap_page' ] );
 
-        $this->include_file( 'handlers/class-ss-yoast-sitemap-handler.php' );
+        $this->include_file( 'handlers/class-rank-math-handler.php' );
     }
 
     public function register_sitemap_page() {
-        if ( ! class_exists( 'WPSEO_Sitemaps_Router' ) ) {
+        if ( ! class_exists( '\RankMath\Sitemap\Router' ) ) {
             return;
         }
 
-        $url = \WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' );
+        $url = Router::get_base_url( 'sitemap_index.xml' );
         Util::debug_log( 'Adding sitemap URL to queue: ' . $url );
         /** @var \Simply_Static\Page $static_page */
         $static_page = Page::query()->find_or_initialize_by( 'url', $url );
         $static_page->set_status_message( __( "Sitemap URL", 'simply-static' ) );
         $static_page->found_on_id = 0;
-        $static_page->handler = Yoast_Sitemap_Handler::class;
+        $static_page->handler = Rank_Math_Sitemap_Handler::class;
         $static_page->save();
     }
 
@@ -32,6 +39,6 @@ class Yoast_Integration extends Integration {
      * @return bool
      */
     public function can_run() {
-        return defined( 'WPSEO_FILE' );
+        return class_exists( 'RankMath' );
     }
 }

--- a/src/integrations/class-seopress-integration.php
+++ b/src/integrations/class-seopress-integration.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Simply_Static;
+
+class SEOPress_Integration extends Integration {
+
+    protected $id = 'seopress';
+
+    /**
+     * Run the integration.
+     *
+     * @return void
+     */
+    public function run() {
+        add_action( 'ss_after_setup_task', [ $this, 'register_sitemap_pages' ] );
+    }
+
+    public function register_sitemap_pages() {
+        $url = home_url( 'sitemaps.xml' );
+
+        $this->register_sitemap_page( $url );
+    }
+
+    public function register_sitemap_page( $url ) {
+        Util::debug_log( 'Adding sitemap URL to queue: ' . $url );
+        /** @var \Simply_Static\Page $static_page */
+        $static_page = Page::query()->find_or_initialize_by( 'url', $url );
+        $static_page->set_status_message( __( "Sitemap URL", 'simply-static' ) );
+        $static_page->found_on_id = 0;
+        $static_page->save();
+    }
+
+    /**
+     * Can this integration run?
+     * @return bool
+     */
+    public function can_run() {
+        return defined( 'SEOPRESS_VERSION' );
+    }
+}

--- a/src/integrations/class-yoast-integration.php
+++ b/src/integrations/class-yoast-integration.php
@@ -29,7 +29,7 @@ class Yoast_Integration extends Integration {
      * Can this integration run?
      * @return bool
      */
-    public function can_run() {die('Running Yoast');
+    public function can_run() {
         return defined( 'WPSEO_FILE' );
     }
 }

--- a/src/integrations/class-yoast-integration.php
+++ b/src/integrations/class-yoast-integration.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Simply_Static;
+
+class Yoast_Integration extends Integration {
+
+    protected $id = 'yoast';
+
+    public function run() {
+         add_action( 'ss_after_setup_task', [ $this, 'register_sitemap_page' ] );
+    }
+
+    public function register_sitemap_page() {
+        if ( ! class_exists( 'WPSEO_Sitemaps_Router' ) ) {
+            return;
+        }
+
+        $url = \WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' );
+        Util::debug_log( 'Adding sitemap URL to queue: ' . $url );
+        /** @var \Simply_Static\Page $static_page */
+        $static_page = Page::query()->find_or_initialize_by( 'url', $url );
+        $static_page->set_status_message( __( "Sitemap URL", 'simply-static' ) );
+        $static_page->found_on_id = 0;
+        $static_page->handler = Yoast_Sitemap_Handler::class;
+        $static_page->save();
+    }
+
+    /**
+     * Can this integration run?
+     * @return bool
+     */
+    public function can_run() {die('Running Yoast');
+        return defined( 'WPSEO_FILE' );
+    }
+}

--- a/src/models/class-ss-page.php
+++ b/src/models/class-ss-page.php
@@ -43,6 +43,7 @@ class Page extends Model {
 		'content_hash'        => 'BINARY(20) NULL',
 		'error_message'       => 'VARCHAR(255) NULL',
 		'status_message'      => 'VARCHAR(255) NULL',
+        'handler'             => 'VARCHAR(255) NULL',
 		'last_checked_at'     => "DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'",
 		'last_modified_at'    => "DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'",
 		'last_transferred_at' => "DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'",
@@ -163,4 +164,29 @@ class Page extends Model {
 	public function is_type( $content_type ) {
 		return stripos( $this->content_type, $content_type ) !== false;
 	}
+
+    public function get_handler_class() {
+        $handler = $this->handler ?? Page_Handler::class;
+
+        if ( ! class_exists( $handler ) ) {
+            $handler = '\Simply_Static\\' . $handler;
+        }
+
+        if ( ! class_exists( $handler ) ) {
+            $handler = Page_Handler::class;
+        }
+
+        return $handler;
+    }
+
+    /**
+     * Get the Page Handler based on the column saved.
+     *
+     * @return Page_Handler
+     */
+    public function get_handler() {
+        $handler_class = $this->get_handler_class();
+
+        return new $handler_class( $this );
+    }
 }

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -273,7 +273,7 @@ class Fetch_Urls_Task extends Task {
 	 * for which page it was found on if the ID isn't yet set or if the record
 	 * hasn't been updated in this instance of static generation yet.
 	 *
-	 * @param Simply_Static\Page $static_page The record for the parent page.
+	 * @param \Simply_Static\Page $static_page The record for the parent page.
 	 * @param string             $child_url   The URL of the child page.
 	 * @param string             $start_time  Static generation start time.
 	 * @return void
@@ -282,6 +282,7 @@ class Fetch_Urls_Task extends Task {
 		$child_static_page = Page::query()->find_or_create_by( 'url' , $child_url );
 		if ( $child_static_page->found_on_id === null || $child_static_page->updated_at < $this->archive_start_time ) {
 			$child_static_page->found_on_id = $static_page->id;
+            $child_static_page->handler = $static_page->get_handler_class();
 			$child_static_page->save();
 		}
 	}

--- a/src/tasks/class-ss-setup-task.php
+++ b/src/tasks/class-ss-setup-task.php
@@ -56,7 +56,7 @@ class Setup_Task extends Task {
 		//->delete_all();
 
 		// add origin url and additional urls/files to database.
-		$additional_urls = $this->options->get( 'additional_urls' );
+		$additional_urls = apply_filters( 'ss_setup_task_additional_urls', $this->options->get( 'additional_urls' ) );
 
 		self::add_origin_and_additional_urls_to_db( $additional_urls );
 		self::add_additional_files_to_db( $this->options->get( 'additional_files' ) );

--- a/src/tasks/class-ss-transfer-files-locally-task.php
+++ b/src/tasks/class-ss-transfer-files-locally-task.php
@@ -40,7 +40,7 @@ class Transfer_Files_Locally_Task extends Task {
 
 		// return true when done (no more pages).
 		if ( $pages_processed >= $total_pages ) {
-			do_action( 'ss_finished_transferring_files_locally' );
+			do_action( 'ss_finished_transferring_files_locally', $local_dir );
 		}
 
 		return $pages_processed >= $total_pages;
@@ -98,6 +98,8 @@ class Transfer_Files_Locally_Task extends Task {
 					$static_page->set_error_message( 'Destination file exists and is unwriteable' );
 				}
 			}
+
+            do_action( 'simply_static_page_file_transferred', $static_page, $destination_dir );
 
 			$static_page->last_transferred_at = Util::formatted_datetime();
 			$static_page->save();


### PR DESCRIPTION
Closes #62 

### Changes

Adds a way to load integrations and different page handlers.
Adding a new version to the plugin (@patrickposner feel free to change it to the correct one, I did that only to fire DB upgrader)

Added Integrations for:
- Yoast SEO
- All in One SEO
- Rank Math
- SEOPress

### Test Steps

- [x] Deactivate other SEO plugins
- [x] Install and activate Yoast SEO
- [x] Generate the site
- [x] Check sitemap XML (through TextEdit/Notepad to check XSL path)
- [x] Check if XSL is saved

---

- [x] Deactivate other SEO plugins
- [x] Install and activate All In One SEO
- [x] Generate the site
- [x] Check sitemap XML (through TextEdit/Notepad to check XSL path)
- [x] Check if XSL is saved

---

- [x] Deactivate other SEO plugins
- [x] Install and activate Rank Math
- [x] Generate the site
- [x] Check sitemap XML (through TextEdit/Notepad to check XSL path)
- [x] Check if XSL is saved

---

- [x] Deactivate other SEO plugins
- [x] Install and activate SEOPress
- [x] Generate the site
- [x] Check sitemap XML (through TextEdit/Notepad to check XSL path)
- [x] Check if XSL is saved

---

- [x] Deactivate all SEO plugins
- [x] Generate the site
- [x] Check if all is done without errors