### PR TITLE
#77 - Removing backslashes given in script tags

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -316,6 +316,7 @@ class Url_Extractor {
 	 */
 	private function extract_and_replace_urls_in_html() {
 		$html_string = $this->get_body();
+        $html_string = stripslashes( $html_string );
 		$match_tags  = apply_filters( 'ss_match_tags', self::$match_tags );
 
 		$dom = HtmlDomParser::str_get_html( $html_string );

--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -422,6 +422,9 @@ class Url_Extractor {
 
 	private function extract_and_replace_urls_in_script( $text ) {
 
+        // Fix URLs in script JSON and HTML in script templates.
+        $text = stripslashes( $text );
+
 		$text = preg_replace( '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', $this->options->get_destination_url(), html_entity_decode( $text ) );
 
 		return $text;


### PR DESCRIPTION
### Which issue
Closes #77.

### What was done
Before extracting/replacing URLs in `script` tags, we are also removing/stripping backslashes from them.

That fixes any JSON URL potential mismatch and also templates that had their HTML escaped.

### Test Steps

- [ ] Install CookieYes plugin and activate it
- [ ] Confirm there is a cookie banner on the site
- [ ] Generate static files
- [ ] Inside of index.html, search for `id="ckyBannerTemplate"`
- [ ] There shouldn't be malformed closing tags such as `<\/div>`
