### PR TITLE
#80 - Adding bundled assets from Elementor

### DIFF
--- a/src/class-integrations.php
+++ b/src/class-integrations.php
@@ -28,6 +28,7 @@ class Integrations {
            'rank-math' => Rank_Math_Integration::class,
            'aio-seo'   => AIO_SEO_Integration::class,
            'seopress'  => SEOPress_Integration::class,
+           'elementor' => Elementor_Integration::class
        ] );
     }
 
@@ -38,5 +39,6 @@ class Integrations {
         require_once $path . 'class-rank-math-integration.php';
         require_once $path . 'class-aio-seo-integration.php';
         require_once $path . 'class-seopress-integration.php';
+        require_once $path . 'class-elementor-integration.php';
     }
 }

--- a/src/integrations/class-elementor-integration.php
+++ b/src/integrations/class-elementor-integration.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Simply_Static;
+
+use function Clue\StreamFilter\fun;
+
+class Elementor_Integration extends Integration {
+    /**
+     * Given plugin handler ID.
+     *
+     * @var string Handler ID.
+     */
+    protected $id = 'elementor';
+
+    /**
+     * Can this integration run?
+     *
+     * @return bool
+     */
+    public function can_run() {
+        return defined( 'ELEMENTOR_VERSION' );
+    }
+
+    /**
+     * Run the integration.
+     *
+     * @return void
+     */
+    public function run() {
+        add_action( 'ss_after_setup_task', [ $this, 'register_assets' ] );
+    }
+
+    /**
+     * Register Elementor Assets to be added that are loaded conditionally
+     *
+     * @return void
+     */
+    public function register_assets() {
+        $js_bundles_folder = trailingslashit( ELEMENTOR_PATH ) . 'assets/js/';
+        $files             = scandir( $js_bundles_folder );
+        $only_bundle_min   = array_filter( $files, function( $file ) {
+           return strpos( $file, 'bundle.min.js' );
+        });
+
+        foreach ( $only_bundle_min as $minified_file ) {
+            $url = trailingslashit( ELEMENTOR_URL ) . 'assets/js/' . $minified_file;
+            Util::debug_log( 'Adding elementor bundle asset to queue: ' . $url );
+            /** @var \Simply_Static\Page $static_page */
+            $static_page = Page::query()->find_or_initialize_by( 'url', $url );
+            $static_page->set_status_message( __( 'Elementor AssetL', 'simply-static' ) );
+            $static_page->found_on_id = 0;
+            $static_page->save();
+        }
+    }
+}


### PR DESCRIPTION
Closes #80 

### What changed

Added an Elementor integration that creates "static pages/additional URLs" for each Elementor `bundle.min.js` asset.

### How to test

- [x] Install Elementor and Activate
- [x] Create a simple home page, with Video widget (add any video, for example: `https://elementor.com/marketing/wp-content/uploads/2021/06/02_MainVideo_1066_600_HR201-1.mp4` as external URL)
- [x] Put it as home page so it's on index.html
- [x] Generate static site
- [x] Check wp-content/plugins/elementor/assets/js/ inside of the ZIPPED file
- [x] There should be various bundle.min.js
- [x] Put the static site folder on a localhost server (or a hosted one) to test
- [x] Video should load
- [x] Scripts should be found (no console errors on not found files)