### PR TITLE
#67 - If the Page is of certain content_type, save it as file

### DIFF
--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -155,7 +155,7 @@ class Url_Fetcher {
 	 * This will also create directories as needed so that a file could be
 	 * created at the returned file path.
 	 *
-	 * @param Simply_Static\Page $static_page The Simply_Static\Page
+	 * @param \Simply_Static\Page $static_page The Simply_Static\Page
 	 *
 	 * @return string|null                The relative file path of the file
 	 */
@@ -176,7 +176,7 @@ class Url_Fetcher {
 
 		// If there's no extension, we're going to create a directory with the
 		// filename and place an index.html/xml file in there.
-		if ( $path_info['extension'] === '' ) {
+		if ( $path_info['extension'] === '' && ! $static_page->is_binary_file() ) {
 			if ( $path_info['filename'] !== '' ) {
 				// the filename would be blank for the root url, in that
 				// instance we don't want to add an extra slash
@@ -196,7 +196,7 @@ class Url_Fetcher {
 			Util::debug_log( "Unable to create temporary directory: " . $this->archive_dir . urldecode( $relative_file_dir ) );
 			$static_page->set_error_message( 'Unable to create temporary directory' );
 		} else {
-			$relative_filename = urldecode( $relative_file_dir ) . $path_info['filename'] . '.' . $path_info['extension'];
+			$relative_filename = urldecode( $relative_file_dir ) . $path_info['filename'] . ( $path_info['extension'] ? '.' . $path_info['extension'] : '' );
 			Util::debug_log( "New filename for static page: " . $relative_filename );
 
 			// check that file doesn't exist OR exists but is writeable

--- a/src/models/class-ss-page.php
+++ b/src/models/class-ss-page.php
@@ -165,6 +165,15 @@ class Page extends Model {
 		return stripos( $this->content_type, $content_type ) !== false;
 	}
 
+    /**
+     * Return if it's a binary file.
+     *
+     * @return bool
+     */
+    public function is_binary_file() {
+        return $this->is_type('application/octet-stream');
+    }
+
     public function get_handler_class() {
         $handler = $this->handler ?? Page_Handler::class;
 


### PR DESCRIPTION
Closes #67 

### What changed

Checks if there is a static page without extension but also if it's a binary file or not. 
If it is, will be saved as a file instead of creating a directory.

### Testing

- [ ] Create a _header file inside of the WP folder (where wp-config.php is) and add some text in it to test if it'll be copied correctly
- [ ] Add the absolute path to the file in "Additional Files"
- [ ] Generate the static site
- [ ] Check if there is a _header file inside of the zipped folder and check if it has the correct text inside