### PR TITLE
#89 - Removing simply_static_page query from URL before being replaced

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -560,6 +560,8 @@ class Url_Extractor {
 			$url = $this->convert_offline_url( $url );
 		}
 
+        $url = remove_query_arg( 'simply_static_page', $url );
+
 		return $url;
 	}
 


### PR DESCRIPTION
Closes #89

### What's done

When replacing and converting the URLs, we're removing the query string from the URL. 
Not on fetch as this is being used for page handlers.

### Test

- [x] Generate a site
- [x] Check index.html and other pages, there should be a simply_static_page in URLs
- [x] Install a few SEO plugins
- [x] Generate site
- [x] Check if Sitemap XML are done correctly