### PR TITLE
Make nonce on generate page unique to avoid clashing with other plugins that use nonces

### DIFF
--- a/js/admin-generate.js
+++ b/js/admin-generate.js
@@ -39,7 +39,7 @@ jQuery(document).ready(function ($) {
 	// where action is one of 'start', 'continue', 'cancel'
 	function send_action_to_archive_manager(action) {
 		var data = {
-			'_ajax_nonce': $('#_wpnonce').val(),
+			'_ajax_nonce': $('#simply_static_nonce').val(),
 			'action': 'static_archive_action',
 			'perform': action
 		};
@@ -86,7 +86,7 @@ jQuery(document).ready(function ($) {
 
 	function display_export_log() {
 		var data = {
-			'_ajax_nonce': $('#_wpnonce').val(),
+			'_ajax_nonce': $('#simply_static_nonce').val(),
 			'action': 'render_export_log',
 			'page': 1,
 			'per_page': STATIC_PAGES_PER_PAGE
@@ -102,7 +102,7 @@ jQuery(document).ready(function ($) {
 
 	function display_activity_log() {
 		var data = {
-			'_ajax_nonce': $('#_wpnonce').val(),
+			'_ajax_nonce': $('#simply_static_nonce').val(),
 			'action': 'render_activity_log'
 		};
 
@@ -129,7 +129,7 @@ jQuery(document).ready(function ($) {
 		}
 
 		var data = {
-			'_ajax_nonce': $('#_wpnonce').val(),
+			'_ajax_nonce': $('#simply_static_nonce').val(),
 			'action': 'render_export_log',
 			'page': page,
 			'per_page': STATIC_PAGES_PER_PAGE

--- a/views/generate.php
+++ b/views/generate.php
@@ -6,7 +6,7 @@ namespace Simply_Static;
 
 <div class='wrap' id='generatePage'>
 
-	<?php wp_nonce_field( 'simply-static_generate' ) ?>
+	<?php wp_nonce_field( 'simply-static_generate', 'simply_static_nonce' ) ?>
 
 	<div class='actions'>
 		<input id='generate' class='button button-primary button-hero <?php if ( ! $this->archive_generation_done ) { echo 'hide'; } ?>' type='submit' name='generate' value='<?php _e( "Generate Static Files", 'simply-static' ); ?>' />


### PR DESCRIPTION
I recently experienced an issue on a website I manage where, when I go to the Generate page, all the Simply Static-related `admin-ajax.php` requests were hitting 403 Forbidden errors. I tracked down the issue which was that the AJAX requests were using the wrong nonce! Turns out [another plugin](https://wordpress.org/plugins/miniorange-saml-20-single-sign-on/) I had activated also set a generic nonce and the Simply Static javascript was picking up that nonce instead of the one set by SS. This PR makes the nonce name and ID unique to prevent this type of clashing with other plugins.