### PR TITLE
#81 - Remembering Settings

### DIFF
--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -57,24 +57,20 @@ jQuery( document ).ready( function( $ ) {
 
 		if ( $radio.val() == 'absolute' ) {
 			$( '#destinationHost' )
-				.prop( 'disabled', false );
+				.prop( 'readonly', false );
 			$( '#destinationScheme' )
-				.prop( 'disabled', false );
+				.prop( 'readonly', false );
 		} else {
-			$( '#destinationHost' )
-				.val('')
-				.prop( 'disabled', true );
+			$( '#destinationHost' ).prop( 'readonly', true );
 			$( '#destinationScheme' )
-				.prop( 'disabled', true )
+				.prop( 'readonly', true )
 		}
 
 		if ( $radio.val() == 'relative' ) {
 			$( '#relativePath' )
-				.prop( 'disabled', false );
+				.prop( 'readonly', false );
 		} else {
-			$( '#relativePath' )
-				.val('')
-				.prop( 'disabled', true );
+			$( '#relativePath' ).prop( 'readonly', true );
 		}
 	}
 

--- a/src/class-ss-options.php
+++ b/src/class-ss-options.php
@@ -144,6 +144,15 @@ class Options {
 	 * @return string The destination URL
 	 */
 	public function get_destination_url() {
-		return $this->get( 'destination_scheme' ) . $this->get( 'destination_host' );
+
+        switch ( $this->get( 'destination_url_type' ) ) {
+            case 'absolute':
+                return $this->get( 'destination_scheme' ) . $this->get( 'destination_host' );
+                break;
+            case 'relative':
+                return $this->get( 'relative_path' );
+        }
+
+		return './';
 	}
 }

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -451,6 +451,8 @@ class Plugin {
 			$destination_scheme = $this->fetch_post_value( 'destination_scheme' );
 			$destination_host   = untrailingslashit( $this->fetch_post_value( 'destination_host' ) );
 		}
+        $destination_scheme = $this->fetch_post_value( 'destination_scheme' );
+        $destination_host   = untrailingslashit( $this->fetch_post_value( 'destination_host' ) );
 
 		// Set URLs to exclude
 		$urls_to_exclude = array();

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -441,16 +441,6 @@ class Plugin {
 		// Set destination url type / scheme / host
 		$destination_url_type = $this->fetch_post_value( 'destination_url_type' );
 
-		if ( $destination_url_type == 'offline' ) {
-			$destination_scheme = '';
-			$destination_host   = '.';
-		} else if ( $destination_url_type == 'relative' ) {
-			$destination_scheme = '';
-			$destination_host   = '';
-		} else {
-			$destination_scheme = $this->fetch_post_value( 'destination_scheme' );
-			$destination_host   = untrailingslashit( $this->fetch_post_value( 'destination_host' ) );
-		}
         $destination_scheme = $this->fetch_post_value( 'destination_scheme' );
         $destination_host   = untrailingslashit( $this->fetch_post_value( 'destination_host' ) );
 


### PR DESCRIPTION
Closes #81.

### What changed
Removed code that resets the settings when changing destination type (both in JS and PHP).
Refactored method get_destination_url to include the right "URL path" based on destination type.

### Test

**Test thoroughly the static site generated for each destination type while other settings are still there saved.**

- [x] All Settings changed and saved (so both absolute and relative is saved)
- [x] Generate site for Absolute URL type. Test static site.
- [x] Generate site for Relative type. Test static site.
- [x] Generate site for Offline type. Test static site.
