### PR TITLE
#61 - Integration with Brizy to convert URLs.

### DIFF
--- a/src/class-integrations.php
+++ b/src/class-integrations.php
@@ -28,7 +28,8 @@ class Integrations {
            'rank-math' => Rank_Math_Integration::class,
            'aio-seo'   => AIO_SEO_Integration::class,
            'seopress'  => SEOPress_Integration::class,
-           'elementor' => Elementor_Integration::class
+           'elementor' => Elementor_Integration::class,
+           'brizy'    => Brizy_Integration::class
        ] );
     }
 
@@ -40,5 +41,6 @@ class Integrations {
         require_once $path . 'class-aio-seo-integration.php';
         require_once $path . 'class-seopress-integration.php';
         require_once $path . 'class-elementor-integration.php';
+        require_once $path . 'class-brizy-integration.php';
     }
 }

--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -532,7 +532,12 @@ class Url_Extractor {
 
 		if ( $url && Util::is_local_url( $url ) ) {
 			// add to extracted urls queue
-			$this->extracted_urls[] = Util::remove_params_and_fragment( $url );
+			$this->extracted_urls[] = apply_filters(
+                'simply_static_extracted_url',
+                Util::remove_params_and_fragment( $url ),
+                $url,
+                $this->static_page
+            );
 
 			$url = $this->convert_url( $url );
 		}
@@ -548,6 +553,9 @@ class Url_Extractor {
 	 * @return string      Converted URL
 	 */
 	private function convert_url( $url ) {
+
+        $url = apply_filters( 'simply_static_pre_converted_url', $url, $this->static_page, $this );
+
 		if ( $this->options->get( 'destination_url_type' ) == 'absolute' ) {
 			$url = $this->convert_absolute_url( $url );
 		} else if ( $this->options->get( 'destination_url_type' ) == 'relative' ) {
@@ -558,7 +566,7 @@ class Url_Extractor {
 
         $url = remove_query_arg( 'simply_static_page', $url );
 
-		return $url;
+		return apply_filters( 'simply_static_converted_url', $url, $this->static_page, $this );
 	}
 
 	/**

--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -126,6 +126,7 @@ class Url_Fetcher {
 			}
 
 			if ( $relative_filename !== null ) {
+                $relative_filename      = apply_filters( 'simply_static_relative_filename', $relative_filename, $static_page );
 				$static_page->file_path = $relative_filename;
 				$file_path              = $this->archive_dir . $relative_filename;
 
@@ -191,6 +192,11 @@ class Url_Fetcher {
 			}
 		}
 
+        $page_handler = $static_page->get_handler();
+
+        $path_info = apply_filters( 'simply_static_page_path_info', $page_handler->get_path_info( $path_info ), $static_page );
+        $relative_file_dir = apply_filters( 'simple_static_page_relative_file_dir', $page_handler->get_relative_dir( $relative_file_dir ), $static_page );
+
 		$create_dir = wp_mkdir_p( $this->archive_dir . urldecode( $relative_file_dir ) );
 		if ( $create_dir === false ) {
 			Util::debug_log( "Unable to create temporary directory: " . $this->archive_dir . urldecode( $relative_file_dir ) );
@@ -214,7 +220,7 @@ class Url_Fetcher {
 
 	public static function remote_get( $url, $filename = null ) {
 		$basic_auth_digest = Options::instance()->get( 'http_basic_auth_digest' );
-
+        Util::debug_log( "Fetching URL: " . $url );
 		$args = apply_filters(
 			'ss_remote_get_args',
 			array(

--- a/src/handlers/class-brizy-image-handler.php
+++ b/src/handlers/class-brizy-image-handler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Simply_Static;
+
+class Brizy_Image_Handler extends Page_Handler
+{
+
+    public function prepare_url( $url )
+    {
+        return htmlspecialchars_decode($url);
+    }
+
+    public function get_path_info( $path_info ) {
+
+        $media_path = $this->get_path_info_for_url( $this->page->url );
+
+        $path_info['basename']  = $media_path['basename'];
+        $path_info['filename']  = $media_path['filename'];
+        $path_info['extension'] = $media_path['extension'];
+
+        return $path_info;
+    }
+
+    public function get_path_info_for_url( $url ) {
+
+        $parsed_url = parse_url( $this->prepare_url( $url ) );
+        $queries    = explode( '&', $parsed_url['query'] );
+
+        foreach ( $queries as $query ) {
+            $query_info = explode( '=', $query );
+            $query_name = $query_info[0];
+
+            if ( $query_name === 'brizy_media' ) {
+                return Util::url_path_info( $query_info[1] );
+            }
+        }
+
+        return [];
+    }
+
+    public function get_relative_dir( $relative_dir ) {
+        return 'wp-content/uploads/brizy/';
+    }
+
+    public function get_converted_url( $url ) {
+        $path_info = $this->get_path_info_for_url( $url );
+
+        return '/' . $this->get_relative_dir('') . $path_info['basename'];
+    }
+}

--- a/src/handlers/class-ss-page-handler.php
+++ b/src/handlers/class-ss-page-handler.php
@@ -59,6 +59,8 @@ class Page_Handler {
 	public function run_hooks() {
 	}
 
-	public function after_file_fetch( $destination_dir ) {
-	}
+	public function after_file_fetch( $destination_dir ) {}
+
+    public function get_path_info( $path_info ) { return $path_info; }
+    public function get_relative_dir( $relative_dir ) { return $relative_dir; }
 }

--- a/src/integrations/class-brizy-integration.php
+++ b/src/integrations/class-brizy-integration.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Simply_Static;
+
+class Brizy_Integration extends Integration {
+
+    /**
+     * Given plugin handler ID.
+     *
+     * @var string Handler ID.
+     */
+    protected $id = 'brizy';
+
+
+    /**
+     * Run the integration.
+     *
+     * @return void
+     */
+    public function run() {
+        add_action( 'simply_static_extracted_url', [ $this, 'maybe_retain_url' ], 20, 2 );
+        add_filter( 'simply_static_handler_class_on_url_found', [ $this, 'set_brizy_page_handler' ], 20, 2 );
+        add_filter( 'simply_static_pre_converted_url', [ $this, 'change_converted_url' ], 20, 2 );
+        $this->include_file( 'handlers/class-brizy-image-handler.php');
+    }
+
+    /**
+     * @param $url
+     * @param \Simply_Static\Page $static_page
+     * @return mixed
+     */
+    public function change_converted_url( $url, $static_page ) {
+        if ( ! $this->is_brizy_media( $url ) ) {
+            return $url;
+        }
+
+        $handler = new Brizy_Image_Handler( $static_page );
+
+        return $handler->get_converted_url( $url );
+    }
+
+    public function set_brizy_page_handler( $handler_class, $child_url ) {
+        if ( ! $this->is_brizy_media( $child_url ) ) {
+            return $handler_class;
+        }
+
+        return Brizy_Image_Handler::class;
+    }
+
+    /**
+     * Let's retain the URL when extracting the data.
+     * Otherwise it will look like a homepage instead of image.
+     *
+     * @param $cleaned_url
+     * @param $origin_url
+     * @return mixed
+     */
+    public function maybe_retain_url( $cleaned_url, $origin_url ) {
+        if ( ! $this->is_brizy_media( $origin_url ) ) {
+            return $cleaned_url;
+        }
+
+        return $origin_url;
+    }
+
+    public function is_brizy_media( $url ) {
+        $parsed_url = parse_url( $url );
+
+        if ( empty( $parsed_url['query'] ) ) {
+            return false;
+        }
+
+        if ( strpos( $parsed_url['query'], 'brizy_media' ) === false ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function can_run() {
+        return defined( 'BRIZY_VERSION' );
+    }
+}

--- a/src/integrations/class-elementor-integration.php
+++ b/src/integrations/class-elementor-integration.php
@@ -2,8 +2,6 @@
 
 namespace Simply_Static;
 
-use function Clue\StreamFilter\fun;
-
 class Elementor_Integration extends Integration {
     /**
      * Given plugin handler ID.

--- a/src/models/class-ss-page.php
+++ b/src/models/class-ss-page.php
@@ -171,7 +171,7 @@ class Page extends Model {
      * @return bool
      */
     public function is_binary_file() {
-        return $this->is_type('application/octet-stream');
+        return $this->is_type('application/octet-stream') || $this->is_type('image');
     }
 
     public function get_handler_class() {

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -288,7 +288,7 @@ class Fetch_Urls_Task extends Task {
 		$child_static_page = Page::query()->find_or_create_by( 'url', $child_url );
 		if ( $child_static_page->found_on_id === null || $child_static_page->updated_at < $this->archive_start_time ) {
 			$child_static_page->found_on_id = $static_page->id;
-			$child_static_page->handler     = $static_page->get_handler_class();
+			$child_static_page->handler     = apply_filters( 'simply_static_handler_class_on_url_found', $static_page->get_handler_class(), $child_url, $static_page );
 			$child_static_page->save();
 		}
 	}


### PR DESCRIPTION
Related to #61 

### What changed

Added filters around the plugin to manipulate filename, file path and converted URLs.
This is a good base for any future integration.

Added Brizy Integration as an example on how this can be done.

### Test

- [ ] Install Brizy Page builder
- [ ] Change homepage with it
- [ ] Added a few images
- [ ] Convert static page
- [ ] Test it, the images should show

**Note: Code currently doesn't handle different crops and x1, x2 image versions from Brizy. If the code review passes, we'll add support for it as well by using the other query parameter that tells Brizy how to crop/resize the image.**