### PR TITLE
#97 - Fixing 30x Redirects

### DIFF
--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -70,7 +70,7 @@ class Url_Fetcher {
 	 *
 	 * @return boolean                        Was the fetch successful?
 	 */
-	public function fetch( Page $static_page ) {
+	public function fetch( Page $static_page, $prepare_url = true ) {
 		$url = $static_page->url;
 
 		// Windows support.
@@ -92,7 +92,11 @@ class Url_Fetcher {
 		$temp_filename = wp_tempnam();
 
 		Util::debug_log( "Fetching URL and saving it to: " . $temp_filename );
-		$url      = $static_page->get_handler()->prepare_url( $url );
+
+        if ( $prepare_url ) {
+            $url = $static_page->get_handler()->prepare_url( $url );
+        }
+
 		$response = self::remote_get( $url, $temp_filename );
 
 		$filesize = file_exists( $temp_filename ) ? filesize( $temp_filename ) : 0;

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -85,6 +85,15 @@ class Fetch_Urls_Task extends Task {
 				continue;
 			}
 
+            // Not found? It's maybe a redirection page. Let's try it without our param.
+            if ( $static_page->http_status_code === 404 ) {
+                $success = Url_Fetcher::instance()->fetch( $static_page, false );
+
+                if ( ! $success ) {
+                    continue;
+                }
+            }
+
 			// If we get a 30x redirect...
 			if ( in_array( $static_page->http_status_code, array( 301, 302, 303, 307, 308 ) ) ) {
 				$this->handle_30x_redirect( $static_page, $save_file, $follow_urls );


### PR DESCRIPTION
Closes #97 


### What was changed?

The issue with redirects not happening anymore is due to our Page Handler query param we use for various stuff such as SEO sitemaps.

Redirect plugins check the exact URL, not without the query param and thus the redirects didn't work through Simply Static.

The code changed in a way to check for 404 status after 1st fetch. If it's 404, we try again without page handlers (that is, our custom query param).

### Test

- [x] Install plugin "Redirection"
- [x] Create a redirect URL (example: `/sample-page-2/ `to redirect somewhere else)
- [x] Generate Simply Static site
- [x] Check if there is a folder `sample-page-2` and if HTML inside is made to redirect.