### PR TITLE
#77 - CookieYes Integration to fix template

### DIFF
--- a/src/class-integrations.php
+++ b/src/class-integrations.php
@@ -28,7 +28,8 @@ class Integrations {
            'rank-math' => Rank_Math_Integration::class,
            'aio-seo'   => AIO_SEO_Integration::class,
            'seopress'  => SEOPress_Integration::class,
-           'elementor' => Elementor_Integration::class
+           'elementor' => Elementor_Integration::class,
+           'cookieyes' => CookieYes_Integration::class
        ] );
     }
 
@@ -40,5 +41,6 @@ class Integrations {
         require_once $path . 'class-aio-seo-integration.php';
         require_once $path . 'class-seopress-integration.php';
         require_once $path . 'class-elementor-integration.php';
+        require_once $path . 'class-cookieyes-integration.php';
     }
 }

--- a/src/integrations/class-cookieyes-Integration.php
+++ b/src/integrations/class-cookieyes-Integration.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Simply_Static;
+
+use voku\helper\SimpleHtmlDom;
+
+class CookieYes_Integration extends  Integration {
+
+    /**
+     * Given plugin handler ID.
+     *
+     * @var string Handler ID.
+     */
+    protected $id = 'cookieyes';
+
+    /**
+     * Can this integration run?
+     *
+     * @return bool
+     */
+    public function can_run() {
+        return defined( 'CKY_APP_URL' );
+    }
+
+    /**
+     * Run the integration.
+     *
+     * @return void
+     */
+    public function run() {
+        add_action( 'ss_after_extract_and_replace_urls_in_html', [ $this, 'fix_cookieyes_template' ] );
+    }
+
+    /**
+     * @param SimpleHtmlDom$dom
+     * @return void
+     */
+    public function fix_cookieyes_template( $dom ) {
+        $tags = $dom->find( 'script' );
+
+        foreach ( $tags as $tag ) {
+            if ( 'ckyBannerTemplate' !== $tag->getAttribute( 'id' ) ) {
+                continue;
+            }
+
+            $tag->innertext = preg_replace('/<\\\/i', '<', $tag->innertext );
+        }
+    }
+}


### PR DESCRIPTION
Closes #77 

### What's done

Adding a CookieYes integration to target only the CookieYes Banner script template.

### Test

- [ ] Have the CookieYes plugin installed
- [ ] Generate static site
- [ ] Search for id="ckyBannerTemplate" to see if the tag is fine and without <\/div or similar HTML.