### PR TITLE
prevent null value

### DIFF
--- a/src/class-page-handlers.php
+++ b/src/class-page-handlers.php
@@ -61,6 +61,10 @@ class Page_Handlers {
 
 		$page = $this->get_static_page();
 
+		if (!$page) {
+			return;
+		}
+
 		$handler = $page->get_handler();
 
 		$handler->run_hooks();


### PR DESCRIPTION
some times I got php fatal error on get_handler() function, so this prevent the page null value