### PR TITLE
#107 - Converting to sitemap.xml

### DIFF
--- a/src/handlers/class-ss-rank-math-sitemap-handler.php
+++ b/src/handlers/class-ss-rank-math-sitemap-handler.php
@@ -54,26 +54,60 @@ class Rank_Math_Sitemap_Handler extends Page_Handler {
 	 * @return void
 	 */
 	public function after_file_fetch( $destination_dir ) {
-		$destination_path = Util::combine_path( $destination_dir, '/main-sitemap.xsl' );
-
-		if ( file_exists( $destination_path ) ) {
-			return;
-		}
-
-		Util::debug_log( 'Getting content for main-sitemap.xsl' );
-		ob_start();
-		$this->generate_xsl();
-		$xsl_content   = ob_get_clean();
-		$temp_filename = wp_tempnam();
-		file_put_contents( $temp_filename, $xsl_content );
-		$rename = rename( $temp_filename, $destination_path );
-
-		if ( $rename === false ) {
-			Util::debug_log( 'Cannot create ' . $destination_path );
-		} else {
-			Util::debug_log( 'Created ' . $destination_path );
-		}
+        $this->save_xsl( $destination_dir );
+        $this->rename_sitemap( $destination_dir );
 	}
+
+    /**
+     * Rename sitemap to sitemap.xml
+     *
+     * @param string $destination_dir Destination directory.
+     * @return void
+     */
+    protected function rename_sitemap( $destination_dir ) {
+        $sitemap_xml = Util::combine_path( $destination_dir, '/sitemap_index.xml' );
+        if ( ! file_exists( $sitemap_xml ) ) {
+            return;
+        }
+
+        $new_sitemap_xml = Util::combine_path( $destination_dir, '/sitemap.xml' );
+
+        $copy = copy( $sitemap_xml, $new_sitemap_xml );
+        if ( $copy === false ) {
+            Util::debug_log( 'Cannot copy ' . $sitemap_xml . ' to ' . $new_sitemap_xml );
+        } else {
+
+            Util::debug_log( 'Copied ' . $sitemap_xml . ' to ' . $new_sitemap_xml );
+        }
+    }
+
+    /**
+     * Save XSL.
+     *
+     * @param string $destination_dir Dir path.
+     * @return void
+     */
+    protected function save_xsl( $destination_dir ) {
+        $destination_path = Util::combine_path( $destination_dir, '/main-sitemap.xsl' );
+
+        if ( file_exists( $destination_path ) ) {
+            return;
+        }
+
+        Util::debug_log( 'Getting content for main-sitemap.xsl' );
+        ob_start();
+        $this->generate_xsl();
+        $xsl_content   = ob_get_clean();
+        $temp_filename = wp_tempnam();
+        file_put_contents( $temp_filename, $xsl_content );
+        $rename = rename( $temp_filename, $destination_path );
+
+        if ( $rename === false ) {
+            Util::debug_log( 'Cannot create ' . $destination_path );
+        } else {
+            Util::debug_log( 'Created ' . $destination_path );
+        }
+    }
 
 	/**
 	 * Generate XSL

--- a/src/handlers/class-ss-yoast-sitemap-handler.php
+++ b/src/handlers/class-ss-yoast-sitemap-handler.php
@@ -36,18 +36,51 @@ class Yoast_Sitemap_Handler extends Page_Handler {
 	 * @return void
 	 */
 	public function after_file_fetch( $destination_dir ) {
-
-		$xsl_path         = dirname( WPSEO_FILE ) . '/css/main-sitemap.xsl';
-		$destination_path = Util::combine_path( $destination_dir, '/main-sitemap.xsl' );
-		if ( file_exists( $destination_path ) ) {
-			return;
-		}
-		$copy = copy( $xsl_path, $destination_path );
-		if ( $copy === false ) {
-			Util::debug_log( 'Cannot copy ' . $xsl_path . ' to ' . $destination_path );
-		} else {
-
-			Util::debug_log( 'Copied ' . $xsl_path . ' to ' . $destination_path );
-		}
+        $this->copy_xsl( $destination_dir );
+        $this->rename_sitemap( $destination_dir );
 	}
+
+    /**
+     * Rename sitemap to sitemap.xml
+     *
+     * @param string $destination_dir Destination directory.
+     * @return void
+     */
+    protected function rename_sitemap( $destination_dir ) {
+        $sitemap_xml = Util::combine_path( $destination_dir, '/sitemap_index.xml' );
+        if ( ! file_exists( $sitemap_xml ) ) {
+            return;
+        }
+
+        $new_sitemap_xml = Util::combine_path( $destination_dir, '/sitemap.xml' );
+
+        $copy = copy( $sitemap_xml, $new_sitemap_xml );
+        if ( $copy === false ) {
+            Util::debug_log( 'Cannot copy ' . $sitemap_xml . ' to ' . $new_sitemap_xml );
+        } else {
+
+            Util::debug_log( 'Copied ' . $sitemap_xml . ' to ' . $new_sitemap_xml );
+        }
+    }
+
+    /**
+     * Copy XSL for sitemap
+     *
+     * @param string $destination_dir Destination directory.
+     * @return void
+     */
+    protected function copy_xsl( $destination_dir ) {
+        $xsl_path         = dirname( WPSEO_FILE ) . '/css/main-sitemap.xsl';
+        $destination_path = Util::combine_path( $destination_dir, '/main-sitemap.xsl' );
+        if ( file_exists( $destination_path ) ) {
+            return;
+        }
+        $copy = copy( $xsl_path, $destination_path );
+        if ( $copy === false ) {
+            Util::debug_log( 'Cannot copy ' . $xsl_path . ' to ' . $destination_path );
+        } else {
+
+            Util::debug_log( 'Copied ' . $xsl_path . ' to ' . $destination_path );
+        }
+    }
 }


### PR DESCRIPTION
### Related

Closes #107 

### Changes

Adds code to move Yoast & RankMath sitemaps to sitemap.xml format (copy).

### Test

- [x] Have Yoast SEO plugin active
- [x] Generate static
- [x] Check there is a sitemap.xml the same as the sitemap_index.xml

---

- [x] Have RankMath plugin active
- [x] Generate static
- [x] Check there is a sitemap.xml the same as the sitemap_index.xml