### PR TITLE
Add support for data-srcset in URL extraction

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -30,7 +30,7 @@ class Url_Extractor {
 	protected static $match_tags = array(
 		'a'       => array( 'href', 'urn', 'style' ),
 		'base'    => array( 'href' ),
-		'img'     => array( 'src', 'usemap', 'longdesc', 'dynsrc', 'lowsrc', 'srcset', 'data-src', 'data-bg' ),
+		'img'     => array( 'src', 'usemap', 'longdesc', 'dynsrc', 'lowsrc', 'srcset', 'data-src', 'data-srcset', 'data-bg' ),
 		'picture' => array( 'src', 'srcset' ),
 		'amp-img' => array( 'src', 'srcset' ),
 
@@ -301,7 +301,7 @@ class Url_Extractor {
 					}
 				} else {
 					// srcset is a fair bit different from most html
-					if ( $attribute_name === 'srcset' ) {
+					if ( $attribute_name === 'srcset' || $attribute_name === 'data-srcset' ) {
 						$extracted_urls = $this->extract_urls_from_srcset( $attribute_value );
 					} else {
 						$extracted_urls[] = $attribute_value;


### PR DESCRIPTION
This commit adds support for the data-srcset attribute in URL extraction, ensuring that images loaded via data-* attributes are also processed correctly. Bricks Builder, by default, adds data-srcset when applying lazy load, but we cannot pass this attribute directly to the extract_urls_from_srcset function. Therefore, the logic has been adjusted to handle data-srcset the same way as srcset.