### PR TITLE
Fix background process lock handoff

### DIFF
--- a/src/background/class-ss-background-process.php
+++ b/src/background/class-ss-background-process.php
@@ -104,6 +104,20 @@ abstract class Background_Process extends Async_Request {
 	protected $is_inline = false;
 
 	/**
+	 * Value written to the current process lock by this PHP process.
+	 *
+	 * @var string|null
+	 */
+	protected $process_lock_value = null;
+
+	/**
+	 * Whether this PHP process has already attempted to release its lock.
+	 *
+	 * @var bool
+	 */
+	protected $process_lock_released = false;
+
+	/**
 	 * The status set when process is cancelling.
 	 *
 	 * @var int
@@ -166,9 +180,16 @@ abstract class Background_Process extends Async_Request {
 		$this->schedule_event();
 
 		if ( $this->is_processing() ) {
-			// Process already running.
-			Util::debug_log( 'Dispatch skipped: background process is already running (lock held).' );
-			return false;
+			if ( $this->process_lock_released && $this->owns_process_lock() ) {
+				Util::debug_log( 'Dispatch found a stale lock owned by the current process. Releasing it before dispatching.' );
+				$this->unlock_process();
+			}
+
+			if ( $this->is_processing() ) {
+				// Process already running.
+				Util::debug_log( 'Dispatch skipped: background process is already running (lock held).' );
+				return false;
+			}
 		}
 
 		/**
@@ -698,8 +719,10 @@ abstract class Background_Process extends Async_Request {
 		$lock_duration = ( property_exists( $this, 'queue_lock_time' ) ) ? $this->queue_lock_time : 60; // 1 minute
 		$lock_duration = apply_filters( $this->identifier . '_queue_lock_time', $lock_duration );
 
-		$microtime = microtime();
-		$locked    = set_site_transient( $this->get_lock_key(), $microtime, $lock_duration );
+		$microtime                   = microtime();
+		$this->process_lock_value    = $microtime . ':' . uniqid( '', true );
+		$this->process_lock_released = false;
+		$locked                      = set_site_transient( $this->get_lock_key(), $this->process_lock_value, $lock_duration );
 
 		/**
 		 * Action to note whether the background process managed to create its lock.
@@ -729,7 +752,16 @@ abstract class Background_Process extends Async_Request {
 	 * @return $this
 	 */
 	protected function unlock_process() {
-		$unlocked = delete_site_transient( $this->get_lock_key() );
+		$lock_key   = $this->get_lock_key();
+		$lock_value = get_site_transient( $lock_key );
+
+		if ( $lock_value && ! $this->owns_process_lock() && ! $this->is_process_lock_stale( $lock_value ) ) {
+			Util::debug_log( 'Skipping process unlock because the lock is owned by another process.' );
+			return $this;
+		}
+
+		$unlocked                     = delete_site_transient( $lock_key );
+		$this->process_lock_released = true;
 
 		/**
 		 * Action to note whether the background process managed to release its lock.
@@ -743,6 +775,59 @@ abstract class Background_Process extends Async_Request {
 		do_action( $this->identifier . '_process_unlocked', $unlocked, $this->get_chain_id() );
 
 		return $this;
+	}
+
+	/**
+	 * Check whether the current PHP process owns the active lock.
+	 *
+	 * @return bool
+	 */
+	protected function owns_process_lock() {
+		if ( empty( $this->process_lock_value ) ) {
+			return false;
+		}
+
+		$lock_value = get_site_transient( $this->get_lock_key() );
+
+		return is_string( $lock_value ) && hash_equals( $this->process_lock_value, $lock_value );
+	}
+
+	/**
+	 * Check whether a process lock is older than the configured lock duration.
+	 *
+	 * @param string $lock_value Current lock transient value.
+	 *
+	 * @return bool
+	 */
+	protected function is_process_lock_stale( $lock_value ) {
+		$lock_timestamp = $this->get_process_lock_timestamp( $lock_value );
+
+		if ( empty( $lock_timestamp ) ) {
+			return false;
+		}
+
+		$lock_duration = ( property_exists( $this, 'queue_lock_time' ) ) ? $this->queue_lock_time : 60; // 1 minute
+		$lock_duration = apply_filters( $this->identifier . '_queue_lock_time', $lock_duration );
+
+		return ( microtime( true ) - $lock_timestamp ) > $lock_duration;
+	}
+
+	/**
+	 * Extract a Unix timestamp from a process lock value.
+	 *
+	 * @param string $lock_value Current lock transient value.
+	 *
+	 * @return float|null
+	 */
+	protected function get_process_lock_timestamp( $lock_value ) {
+		$microtime = explode( ':', $lock_value, 2 )[0];
+		$parts     = explode( ' ', $microtime );
+
+		if ( count( $parts ) !== 2 || ! is_numeric( $parts[0] ) || ! is_numeric( $parts[1] ) ) {
+			return null;
+		}
+
+		return (float) $parts[1] + (float) $parts[0];
 	}
 
 	/**

--- a/src/tasks/traits/trait-ss-can-process-pages.php
+++ b/src/tasks/traits/trait-ss-can-process-pages.php
@@ -83,16 +83,16 @@ trait canProcessPages {
 	 * Maximum number of seconds process_pages() should run before yielding
 	 * back to the background process dispatcher.
 	 *
-	 * Keeping this well below typical server hard-kill limits (60-120 s)
-	 * prevents the PHP process from being terminated mid-batch, which
-	 * would break the inline-dispatch shutdown-function chain on
-	 * restricted hosting environments (WP Engine, Flywheel, etc.).
+	 * Keeping this below the background process' default 20 second
+	 * continuation window prevents the PHP process from spending too long
+	 * inside a single task before the dispatcher can hand off the next
+	 * request.
 	 *
 	 * Filterable via `simply_static_max_batch_time`.
 	 *
 	 * @var int
 	 */
-	protected $max_batch_time = 50;
+	protected $max_batch_time = 15;
 
 	/**
 	 * Process Pages that have to be processed/transferred.


### PR DESCRIPTION
Updates background process locks to track ownership so an older process does not release a newer process lock. Adds stale-lock detection before unlocks and lets dispatch clear a stale lock owned by the current process before handing off work. Lowers page-processing batches to 15 seconds so tasks yield before the 20-second continuation window.\n\nChecks: php -l src/background/class-ss-background-process.php; php -l src/tasks/traits/trait-ss-can-process-pages.php; git diff --check.