### PR TITLE
Fix redirects for alternate local URL bases

### DIFF
--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -398,14 +398,9 @@ class Url_Fetcher {
 		// a domain with no trailing slash has no path, so we're giving it one
 		$path = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
 
-		$origin_path = wp_parse_url( Util::origin_url(), PHP_URL_PATH );
-
-		if ( null !== $origin_path && '' !== $origin_path ) {
-			$origin_path_length = strlen( $origin_path );
-
-			if ( $origin_path_length > 1 ) { // prevents removal of '/'.
-				$path = substr( $path, $origin_path_length );
-			}
+		$local_path = Util::get_path_from_local_url( Util::remove_params_and_fragment( $static_page->url ) );
+		if ( is_string( $local_path ) && '' !== $local_path ) {
+			$path = $local_path;
 		}
 
 		$path_info = Util::url_path_info( $path );

--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -830,6 +830,124 @@ class Util {
 	}
 
 	/**
+	 * Get all URL bases that should be treated as local during export.
+	 *
+	 * Proxy setups can use a public Origin URL that differs from the actual
+	 * WordPress home/site URL. Redirects and generated asset URLs may still point
+	 * at the real WordPress URL, so all known local bases need to be accepted.
+	 *
+	 * @return array
+	 */
+	public static function local_url_bases() {
+		$bases = array( self::origin_url() );
+
+		if ( function_exists( 'home_url' ) ) {
+			$bases[] = untrailingslashit( home_url() );
+		}
+
+		if ( function_exists( 'site_url' ) ) {
+			$bases[] = untrailingslashit( site_url() );
+		}
+
+		$bases = array_filter( array_map( 'untrailingslashit', $bases ) );
+		$bases = array_values( array_unique( $bases ) );
+
+		usort( $bases, function ( $a, $b ) {
+			$a_path = function_exists( 'wp_parse_url' ) ? wp_parse_url( $a, PHP_URL_PATH ) : parse_url( $a, PHP_URL_PATH );
+			$b_path = function_exists( 'wp_parse_url' ) ? wp_parse_url( $b, PHP_URL_PATH ) : parse_url( $b, PHP_URL_PATH );
+
+			return strlen( (string) $b_path ) <=> strlen( (string) $a_path );
+		} );
+
+		return apply_filters( 'ss_local_url_bases', $bases );
+	}
+
+	/**
+	 * Find the local URL base that matches the given URL.
+	 *
+	 * @param string $url URL to match.
+	 *
+	 * @return string|null
+	 */
+	public static function get_local_url_base( $url ) {
+		if ( ! is_string( $url ) || '' === $url ) {
+			return null;
+		}
+
+		$url_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url );
+		if ( ! is_array( $url_parts ) || empty( $url_parts['host'] ) ) {
+			return null;
+		}
+
+		$url_host = strtolower( preg_replace( '/:\d+$/', '', (string) $url_parts['host'] ) );
+		$url_path = isset( $url_parts['path'] ) ? untrailingslashit( $url_parts['path'] ) : '';
+
+		foreach ( self::local_url_bases() as $base ) {
+			$base_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $base ) : parse_url( $base );
+			if ( ! is_array( $base_parts ) || empty( $base_parts['host'] ) ) {
+				continue;
+			}
+
+			$base_host = strtolower( preg_replace( '/:\d+$/', '', (string) $base_parts['host'] ) );
+			if ( $url_host !== $base_host ) {
+				continue;
+			}
+
+			$base_path = isset( $base_parts['path'] ) ? untrailingslashit( $base_parts['path'] ) : '';
+			if ( '' === $base_path || '/' === $base_path || $url_path === $base_path || strpos( $url_path . '/', trailingslashit( $base_path ) ) === 0 ) {
+				return $base;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Replace a local URL base with another base URL/path.
+	 *
+	 * @param string $url URL to rewrite.
+	 * @param string $replacement Replacement base.
+	 *
+	 * @return string
+	 */
+	public static function replace_local_url_base( $url, $replacement ) {
+		$base = self::get_local_url_base( $url );
+		if ( null === $base ) {
+			return $url;
+		}
+
+		$url_parts  = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url );
+		$base_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $base ) : parse_url( $base );
+
+		if ( ! is_array( $url_parts ) || ! is_array( $base_parts ) ) {
+			return $url;
+		}
+
+		$url_path  = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
+		$base_path = isset( $base_parts['path'] ) ? untrailingslashit( $base_parts['path'] ) : '';
+		$path      = $url_path;
+
+		if ( '' !== $base_path && '/' !== $base_path ) {
+			$path = substr( $url_path, strlen( $base_path ) );
+			$path = '' === $path ? '/' : $path;
+		}
+
+		$query    = isset( $url_parts['query'] ) ? '?' . $url_parts['query'] : '';
+		$fragment = isset( $url_parts['fragment'] ) ? '#' . $url_parts['fragment'] : '';
+		$base_url = untrailingslashit( (string) $replacement );
+
+		if ( '' === $base_url ) {
+			return self::add_leading_slash( ltrim( $path, '/' ) ) . $query . $fragment;
+		}
+
+		if ( './' === $replacement ) {
+			return './' . ltrim( $path, '/' ) . $query . $fragment;
+		}
+
+		return $base_url . self::add_leading_slash( ltrim( $path, '/' ) ) . $query . $fragment;
+	}
+
+	/**
 	 * Wrapper around home_url(). Useful for swapping out the URL during debugging.
 	 * @return string home URL
 	 */
@@ -1152,15 +1270,7 @@ class Util {
 	 * @return boolean      true if URL is local, false otherwise
 	 */
 	public static function is_local_url( $url ) {
-		$url_host = self::strip_protocol_from_url( self::remove_params_and_fragment( $url ) );
-		// Strip port if present
-		$url_host = preg_replace( '/:\d+/', '', $url_host );
-
-		$origin_host = self::origin_host();
-		// Strip port if present
-		$origin_host = preg_replace( '/:\d+/', '', $origin_host );
-
-		return apply_filters( 'ss_is_local_url', ( stripos( $url_host, $origin_host ) === 0 ) );
+		return apply_filters( 'ss_is_local_url', null !== self::get_local_url_base( self::remove_params_and_fragment( $url ) ) );
 	}
 
 	/**
@@ -1186,37 +1296,35 @@ class Util {
 	 * @return string       URL sans protocol/host
 	 */
 	public static function get_path_from_local_url( $url ) {
-		// Keep behavior robust: only remove the leading scheme/host (and optional base path),
-		// never replace occurrences inside filenames or deeper path segments.
 		if ( ! is_string( $url ) ) {
 			return $url;
 		}
 
-		// Remove scheme to work with a canonical form like: host[:port]/base/path...
+		$base = self::get_local_url_base( self::remove_params_and_fragment( $url ) );
+		if ( null !== $base ) {
+			$url_parts  = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url );
+			$base_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $base ) : parse_url( $base );
+
+			if ( is_array( $url_parts ) && is_array( $base_parts ) ) {
+				$url_path  = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
+				$base_path = isset( $base_parts['path'] ) ? untrailingslashit( $base_parts['path'] ) : '';
+
+				if ( '' !== $base_path && '/' !== $base_path ) {
+					$url_path = substr( $url_path, strlen( $base_path ) );
+				}
+
+				$query    = isset( $url_parts['query'] ) ? '?' . $url_parts['query'] : '';
+				$fragment = isset( $url_parts['fragment'] ) ? '#' . $url_parts['fragment'] : '';
+
+				return '/' . ltrim( $url_path, '/' ) . $query . $fragment;
+			}
+		}
+
+		// Fallback: origin_host() may include a subdirectory; strip only once at the start.
 		$no_scheme = self::strip_protocol_from_url( $url );
+		$pattern   = '/^' . preg_quote( self::origin_host(), '/' ) . '/';
+		$no_host   = preg_replace( $pattern, '', $no_scheme, 1 );
 
-		// Determine origin components reliably (host and optional base path for subdirectory installs)
-		$origin_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( self::origin_url() ) : parse_url( self::origin_url() );
-		if ( ! is_array( $origin_parts ) ) {
-			$origin_parts = array();
-		}
-		$origin_host = isset( $origin_parts['host'] ) ? $origin_parts['host'] : '';
-		$origin_path = isset( $origin_parts['path'] ) ? untrailingslashit( $origin_parts['path'] ) : '';
-
-		// Build an anchored pattern that matches only the leading host[:port] and optional base path.
-		if ( $origin_host !== '' ) {
-			$host_pattern = '^' . preg_quote( $origin_host, '/' ) . '(?::\d+)?';
-			$base_pattern = $origin_path !== '' ? preg_quote( $origin_path, '/' ) : '';
-			$pattern      = '/' . $host_pattern . $base_pattern . '/';
-			$no_host      = preg_replace( $pattern, '', $no_scheme, 1 );
-		} else {
-			// Fallback: origin_host() may include subdirectory; strip only once at the start to avoid touching filenames.
-			$fallback = self::origin_host();
-			$pattern  = '/^' . preg_quote( $fallback, '/' ) . '/';
-			$no_host  = preg_replace( $pattern, '', $no_scheme, 1 );
-		}
-
-		// Ensure a single leading slash for a clean local path, preserving any query/fragment later.
 		return '/' . ltrim( $no_host, '/' );
 	}
 

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -317,7 +317,6 @@ class Fetch_Urls_Task extends Task {
 	 * @return void
 	 */
 	public function handle_30x_redirect( $static_page, $save_file, $follow_urls ) {
-		$origin_url      = Util::origin_url();
 		$destination_url = $this->options->get_destination_url();
 		$current_url     = $static_page->url;
 
@@ -357,6 +356,10 @@ class Fetch_Urls_Task extends Task {
 				Util::debug_log( "This looks like a redirect from http to https (or visa versa); adding new URL to the queue" );
 				$this->set_url_found_on( $static_page, $redirect_url );
 
+			} else if ( $this->redirect_resolves_to_same_static_path( $current_url, $redirect_url ) ) {
+				Util::debug_log( "This redirect resolves to the same static file path; adding new URL to the queue" );
+				$this->set_url_found_on( $static_page, $redirect_url );
+
 			} else {
 				// check if this is a local URL
 				if ( Util::is_local_url( $redirect_url ) ) {
@@ -369,10 +372,10 @@ class Fetch_Urls_Task extends Task {
 						$static_page->set_status_message( __( "Do not follow", 'simply-static' ) );
 					}
 					// and update the URL
-					// Replace origin host (any scheme) with the configured destination URL to ensure
-					// redirects point to the static site domain even when schemes differ (http/https).
-					$pattern      = '/^(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i';
-					$redirect_url = preg_replace( $pattern, $destination_url, $redirect_url );
+					// Replace the matching local base with the configured destination URL. In proxy
+					// setups the redirect may point to home_url()/site_url() instead of the configured
+					// Origin URL, so use the local base that actually matched the redirect.
+					$redirect_url = Util::replace_local_url_base( $redirect_url, $destination_url );
 
 				}
 
@@ -413,6 +416,51 @@ class Fetch_Urls_Task extends Task {
 				$static_page->save();
 			}
 		}
+	}
+
+	/**
+	 * Check whether two URLs would be written to the same generated file.
+	 *
+	 * Proxy/subdirectory setups can redirect between the configured public origin
+	 * and the real WordPress install URL. Those are not user-facing redirects for
+	 * the static site; they are alternate local bases for the same static path.
+	 *
+	 * @param string $current_url Current URL.
+	 * @param string $redirect_url Redirect target URL.
+	 *
+	 * @return bool
+	 */
+	protected function redirect_resolves_to_same_static_path( $current_url, $redirect_url ) {
+		if ( ! Util::is_local_url( $current_url ) || ! Util::is_local_url( $redirect_url ) ) {
+			return false;
+		}
+
+		$current_path = $this->normalize_static_redirect_path( $current_url );
+		$redirect_path = $this->normalize_static_redirect_path( $redirect_url );
+
+		return '' !== $current_path && $current_path === $redirect_path;
+	}
+
+	/**
+	 * Normalize a local URL to the path Simply Static will generate for it.
+	 *
+	 * @param string $url URL to normalize.
+	 *
+	 * @return string
+	 */
+	protected function normalize_static_redirect_path( $url ) {
+		$url_without_fragment = preg_replace( '/#.*/', '', $url );
+		$path                 = Util::get_path_from_local_url( $url_without_fragment );
+		if ( ! is_string( $path ) || '' === $path ) {
+			return '';
+		}
+
+		$clean_path = Util::remove_params_and_fragment( $path );
+		$query      = Util::is_local_asset_url( $url ) ? '' : substr( $path, strlen( $clean_path ) );
+		$path       = Util::strip_index_filenames_from_url( $clean_path );
+		$path       = trailingslashit( $path );
+
+		return '/' . ltrim( $path, '/' ) . $query;
 	}
 
 	/**


### PR DESCRIPTION
Treat the configured origin, WordPress home URL, and site URL as local bases so proxy and subdirectory exports can resolve paths consistently. Redirect handling now rewrites the matched local base to the destination URL and skips redirect-page creation only when both local URLs generate the same static path. Non-asset query strings are preserved during same-path redirect checks so search and iframe-style query URLs do not collapse onto clean paths.