### PR TITLE
Limit update ZIP archives to changed files

### DIFF
--- a/src/class-ss-archive-creation-job.php
+++ b/src/class-ss-archive-creation-job.php
@@ -158,6 +158,9 @@ class Archive_Creation_Job extends Background_Process {
 				->set( 'archive_start_time', Util::formatted_datetime() )
 				->set( 'archive_end_time', null )
 				->set( 'generate_type', $type )
+				->set( 'zip_batch_offset', null )
+				->set( 'zip_total_files', null )
+				->set( 'zip_files', null )
 				->save();
 
 			Util::debug_log( "Pushing first task to queue: " . $first_task );

--- a/src/tasks/class-ss-create-zip-archive.php
+++ b/src/tasks/class-ss-create-zip-archive.php
@@ -73,6 +73,7 @@ class Create_Zip_Archive_Task extends Task {
 	private function cleanup_batch_state() {
 		$this->options->set( 'zip_batch_offset', null );
 		$this->options->set( 'zip_total_files', null );
+		$this->options->set( 'zip_files', null );
 		$this->options->save();
 	}
 
@@ -119,6 +120,7 @@ class Create_Zip_Archive_Task extends Task {
 		$archive_dir  = $this->options->get_archive_dir();
 		$zip_filename = untrailingslashit( $archive_dir ) . '.zip';
 		$zip_filename = apply_filters( 'ss_zip_filename', $zip_filename, $archive_dir, $this->options );
+		$files        = $this->get_files_to_include( $archive_dir, $is_first_batch );
 
 		// Ensure target directory exists in case a custom path points elsewhere
 		$zip_dir = dirname( $zip_filename );
@@ -149,9 +151,13 @@ class Create_Zip_Archive_Task extends Task {
 			);
 		}
 
+		if ( empty( $files ) ) {
+			return $this->create_empty_zip( $zip_filename );
+		}
+
 		// Prefer ZipArchive (ZIP64-capable) when available; fall back to PclZip for legacy environments.
 		if ( class_exists( '\\ZipArchive' ) ) {
-			return $this->create_zip_batched( $zip_filename, $archive_dir, $batch_offset, $is_first_batch );
+			return $this->create_zip_batched( $zip_filename, $archive_dir, $batch_offset, $is_first_batch, $files );
 		}
 
 		// Fallback to PclZip (no ZIP64 support) if ZipArchive is unavailable.
@@ -160,16 +166,14 @@ class Create_Zip_Archive_Task extends Task {
 
 		Util::debug_log( 'ZipArchive unavailable; falling back to PclZip (no ZIP64 support). Fetching list of files to include in zip' );
 
-		$files    = array();
-		$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $archive_dir, \RecursiveDirectoryIterator::SKIP_DOTS ) );
-
-		foreach ( $iterator as $file_name => $file_object ) {
-			$files[] = realpath( $file_name );
-		}
-
 		Util::debug_log( 'Creating zip archive via PclZip' );
 
-		if ( $zip_archive->create( $files, PCLZIP_OPT_REMOVE_PATH, $archive_dir ) === 0 ) {
+		$remove_path = realpath( $archive_dir );
+		if ( false === $remove_path ) {
+			$remove_path = $archive_dir;
+		}
+
+		if ( $zip_archive->create( $files, PCLZIP_OPT_REMOVE_PATH, $remove_path ) === 0 ) {
 			return new \WP_Error( 'create_zip_failed', __( 'Unable to create ZIP archive', 'simply-static' ) );
 		}
 
@@ -181,16 +185,178 @@ class Create_Zip_Archive_Task extends Task {
 	}
 
 	/**
+	 * Create a valid empty ZIP archive.
+	 *
+	 * @param string $zip_filename Full path to the zip file.
+	 *
+	 * @return string|WP_Error Download URL when complete, WP_Error on failure.
+	 */
+	private function create_empty_zip( $zip_filename ) {
+		Util::debug_log( 'Creating empty ZIP archive' );
+
+		$empty_zip = "PK\005\006" . str_repeat( "\0", 18 );
+		$written   = file_put_contents( $zip_filename, $empty_zip );
+
+		if ( false === $written ) {
+			return new \WP_Error( 'create_zip_failed', __( 'Unable to create ZIP archive', 'simply-static' ) );
+		}
+
+		do_action( 'ss_zip_file_created', (object) array( 'zipname' => $zip_filename ) );
+
+		return Util::abs_path_to_url( $zip_filename );
+	}
+
+	/**
+	 * Get the archive files that should be included in the ZIP.
+	 *
+	 * Full exports package the complete archive directory. Update exports keep
+	 * the previous archive directory, so they must package only files whose page
+	 * records were modified by the current export.
+	 *
+	 * @param string $archive_dir    The archive source directory.
+	 * @param bool   $is_first_batch Whether this is the first ZIP batch.
+	 *
+	 * @return array Absolute file paths.
+	 */
+	private function get_files_to_include( $archive_dir, $is_first_batch ) {
+		$is_update_export = 'update' === $this->options->get( 'generate_type' );
+		$stored_files = $this->options->get( 'zip_files' );
+		if ( $is_update_export && ! $is_first_batch && is_array( $stored_files ) ) {
+			return $stored_files;
+		}
+
+		if ( $is_update_export ) {
+			$files = $this->get_modified_archive_files( $archive_dir );
+		} else {
+			$files = $this->get_all_archive_files( $archive_dir );
+		}
+
+		$files = apply_filters( 'ss_zip_files_to_include', $files, $archive_dir, $this->options, $this );
+		$files = $this->normalize_zip_file_list( $files, $archive_dir );
+
+		Util::debug_log( 'Prepared ' . count( $files ) . ' file(s) for ZIP archive' );
+
+		if ( $is_update_export && $is_first_batch ) {
+			$this->options->set( 'zip_files', $files );
+			$this->options->save();
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Get every file currently present in the archive directory.
+	 *
+	 * @param string $archive_dir The archive source directory.
+	 *
+	 * @return array Absolute file paths.
+	 */
+	private function get_all_archive_files( $archive_dir ) {
+		$files    = array();
+		$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $archive_dir, \RecursiveDirectoryIterator::SKIP_DOTS ) );
+
+		foreach ( $iterator as $path => $file_info ) {
+			if ( ! $file_info->isDir() ) {
+				$files[] = $path;
+			}
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Get files modified by the current update export.
+	 *
+	 * @param string $archive_dir The archive source directory.
+	 *
+	 * @return array Absolute file paths.
+	 */
+	private function get_modified_archive_files( $archive_dir ) {
+		$archive_start_time = $this->options->get( 'archive_start_time' );
+		if ( empty( $archive_start_time ) ) {
+			return array();
+		}
+
+		$pages = Page::query()
+			->where( "file_path IS NOT NULL" )
+			->where( "file_path != ''" )
+			->where( "last_modified_at >= ?", $archive_start_time )
+			->order( 'file_path ASC' )
+			->find();
+
+		if ( empty( $pages ) ) {
+			return array();
+		}
+
+		$files = array();
+		foreach ( $pages as $static_page ) {
+			$files[] = $archive_dir . ltrim( $static_page->file_path, '/\\' );
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Normalize and constrain ZIP include paths to files under the archive dir.
+	 *
+	 * @param array  $files       Candidate absolute or archive-relative paths.
+	 * @param string $archive_dir The archive source directory.
+	 *
+	 * @return array Absolute file paths.
+	 */
+	private function normalize_zip_file_list( $files, $archive_dir ) {
+		if ( ! is_array( $files ) ) {
+			return array();
+		}
+
+		$base_path = realpath( $archive_dir );
+		if ( false === $base_path ) {
+			return array();
+		}
+
+		$base_path_normalized = rtrim( str_replace( '\\', '/', $base_path ), '/' );
+		$normalized_files     = array();
+
+		foreach ( $files as $file ) {
+			if ( ! is_string( $file ) || '' === $file ) {
+				continue;
+			}
+
+			$path = $file;
+			if ( ! preg_match( '/^(?:[A-Za-z]:[\/\\\\]|\/)/', $path ) ) {
+				$path = $archive_dir . ltrim( $path, '/\\' );
+			}
+
+			$real_path = realpath( $path );
+			if ( false === $real_path || ! is_file( $real_path ) ) {
+				continue;
+			}
+
+			$real_path_normalized = str_replace( '\\', '/', $real_path );
+			if ( 0 !== strpos( $real_path_normalized, $base_path_normalized . '/' ) ) {
+				continue;
+			}
+
+			$normalized_files[ $real_path_normalized ] = $real_path;
+		}
+
+		ksort( $normalized_files );
+
+		return array_values( $normalized_files );
+	}
+
+	/**
 	 * Create the zip archive in batches using ZipArchive.
 	 *
 	 * @param string $zip_filename  Full path to the zip file.
 	 * @param string $archive_dir   The archive source directory.
 	 * @param int    $batch_offset  The file index offset to start from.
 	 * @param bool   $is_first_batch Whether this is the first batch.
+	 * @param array  $all_files     Files to add to the ZIP.
 	 *
 	 * @return string|false|WP_Error Download URL when complete, false if more batches needed, WP_Error on failure.
 	 */
-	private function create_zip_batched( $zip_filename, $archive_dir, $batch_offset, $is_first_batch ) {
+	private function create_zip_batched( $zip_filename, $archive_dir, $batch_offset, $is_first_batch, $all_files ) {
 		$batch_size = apply_filters( 'ss_zip_batch_size', self::BATCH_SIZE );
 
 		if ( $is_first_batch ) {
@@ -214,17 +380,11 @@ class Create_Zip_Archive_Task extends Task {
 			);
 		}
 
-		$base_path = untrailingslashit( $archive_dir );
-		$base_len  = strlen( $base_path ) + 1; // account for trailing slash in relative names
-
-		// Collect all file paths from the archive directory.
-		$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $archive_dir, \RecursiveDirectoryIterator::SKIP_DOTS ) );
-		$all_files = array();
-		foreach ( $iterator as $path => $file_info ) {
-			if ( ! $file_info->isDir() ) {
-				$all_files[] = $path;
-			}
+		$base_path = realpath( $archive_dir );
+		if ( false === $base_path ) {
+			$base_path = untrailingslashit( $archive_dir );
 		}
+		$base_len  = strlen( $base_path ) + 1; // account for trailing slash in relative names
 
 		$total_files = count( $all_files );
 


### PR DESCRIPTION
## Summary
- Reset ZIP batch tracking, including the stored update file list, when a new archive job starts or completes.
- Build update ZIP archives from files whose page records changed during the current export, while full exports still include the whole archive directory.
- Normalize ZIP include paths, reuse the stored file list across batches, and create a valid empty ZIP when there are no changed files.

## Verification
- php -l src/class-ss-archive-creation-job.php
- php -l src/tasks/class-ss-create-zip-archive.php