### PR TITLE
Fix progress total caching

### DIFF
--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -692,18 +692,4 @@ class Fetch_Urls_Task extends Task {
 		return $type;
 	}
 
-	/**
-	 * Get total number of pages to process.
-	 * For this task, we don't use the cached values.
-	 *
-	 * @param boolean $cached Whether to use cached values.
-	 *
-	 * @return int|null
-	 * @throws \Exception
-	 */
-	public function get_total_pages( $cached = true ) {
-
-		return $this->get_total_pages_sql();
-
-	}
 }

--- a/src/tasks/traits/trait-ss-can-process-pages.php
+++ b/src/tasks/traits/trait-ss-can-process-pages.php
@@ -318,10 +318,25 @@ trait canProcessPages {
 			return $this->get_total_pages_sql();
 		}
 
-		$count = get_option( 'simply_static_' . static::$task_name . '_total_pages' );
+		$option_name = 'simply_static_' . static::$task_name . '_total_pages';
+		$count       = get_option( $option_name );
+
 		if ( false === $count ) {
 			$count = $this->get_total_pages_sql();
-			update_option( 'simply_static_' . static::$task_name . '_total_pages', $count );
+			update_option( $option_name, $count );
+		} else {
+			$count = (int) $count;
+		}
+
+		if ( 'update' === $this->get_generate_type() ) {
+			$current_total = $this->get_processed_pages() + $this->get_total_pages_sql();
+		} else {
+			$current_total = $this->get_total_pages_sql();
+		}
+
+		if ( $current_total > $count ) {
+			$count = $current_total;
+			update_option( $option_name, $count );
 		}
 
 		return $count;


### PR DESCRIPTION
Updates the shared page-processing total cache so it reuses a single option name, normalizes cached values, and raises the cached total when more work is discovered during processing. Removes the fetch URLs task override so it uses the same total-page caching behavior as other page-processing tasks. Verified the touched PHP files with php -l.