### PR TITLE
Fix export hangs on binary files

### DIFF
--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -267,6 +267,7 @@ class Url_Fetcher {
 				}
 
 				if ( $renamed ) {
+					Util::debug_log( "Saved temp file to: " . $file_path );
 					$static_page->get_handler()->after_file_fetch( $this->archive_dir );
 				}
 			} else {
@@ -350,6 +351,16 @@ class Url_Fetcher {
 			'gz'    => 'application/gzip',
 			'rar'   => 'application/vnd.rar',
 			'7z'    => 'application/x-7z-compressed',
+			'mp3'   => 'audio/mpeg',
+			'm4a'   => 'audio/mp4',
+			'oga'   => 'audio/ogg',
+			'ogg'   => 'audio/ogg',
+			'wav'   => 'audio/wav',
+			'webm'  => 'video/webm',
+			'mp4'   => 'video/mp4',
+			'm4v'   => 'video/mp4',
+			'mov'   => 'video/quicktime',
+			'ogv'   => 'video/ogg',
 			'woff'  => 'font/woff',
 			'woff2' => 'font/woff2',
 			'ttf'   => 'font/ttf',

--- a/src/models/class-ss-model.php
+++ b/src/models/class-ss-model.php
@@ -78,6 +78,16 @@ class Model {
 	}
 
 	/**
+	 * Check whether a field has a non-null value.
+	 *
+	 * @param string $field_name The name of the field to check.
+	 * @return bool Whether the field is set.
+	 */
+	public function __isset( $field_name ) {
+		return array_key_exists( $field_name, $this->data ) && null !== $this->data[ $field_name ];
+	}
+
+	/**
 	 * Set the value of a field for the model
 	 *
 	 * Returns an exception if you try to set a field that isn't one of the

--- a/src/models/class-ss-page.php
+++ b/src/models/class-ss-page.php
@@ -232,8 +232,72 @@ class Page extends Model {
 	 * @return bool
 	 */
 	public function is_binary_file() {
-		if ( $this->is_type( 'application/octet-stream' ) ) {
-			return true;
+		if ( ! is_null( $this->content_type ) ) {
+			$binary_types = array(
+				'application/gzip',
+				'application/octet-stream',
+				'application/pdf',
+				'application/vnd.ms-fontobject',
+				'application/vnd.rar',
+				'application/wasm',
+				'application/x-7z-compressed',
+				'application/x-gzip',
+				'application/x-rar-compressed',
+				'application/x-tar',
+				'application/x-zip-compressed',
+				'application/zip',
+				'audio/',
+				'font/',
+				'image/',
+				'video/',
+			);
+
+			foreach ( $binary_types as $binary_type ) {
+				if ( $this->is_type( $binary_type ) ) {
+					return true;
+				}
+			}
+		}
+
+		if ( isset( $this->file_path ) ) {
+			$extension = strtolower( pathinfo( (string) $this->file_path, PATHINFO_EXTENSION ) );
+			if ( in_array( $extension, array(
+				'7z',
+				'aac',
+				'avif',
+				'bmp',
+				'eot',
+				'gif',
+				'gz',
+				'heic',
+				'ico',
+				'jpeg',
+				'jpg',
+				'm4a',
+				'm4v',
+				'mov',
+				'mp3',
+				'mp4',
+				'oga',
+				'ogg',
+				'ogv',
+				'otf',
+				'pdf',
+				'png',
+				'rar',
+				'tar',
+				'tif',
+				'tiff',
+				'ttf',
+				'wav',
+				'webm',
+				'webp',
+				'woff',
+				'woff2',
+				'zip',
+			), true ) ) {
+				return true;
+			}
 		}
 
 		if ( $this->is_type( 'image' ) ) {

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -261,11 +261,15 @@ class Fetch_Urls_Task extends Task {
 	 * @return void
 	 */
 	public function handle_200_response( $static_page, $save_file, $follow_urls ) {
-		if ( $save_file || $follow_urls ) {
+		$urls = array();
+
+		if ( ( $save_file || $follow_urls ) && $this->can_extract_urls_from_static_page( $static_page ) ) {
 			Util::debug_log( "Extracting URLs and replacing URLs in the static file" );
 			// Fetch all URLs from the page and add them to the queue...
 			$extractor = new Url_Extractor( $static_page );
 			$urls      = $extractor->extract_and_update_urls();
+		} elseif ( $save_file || $follow_urls ) {
+			Util::debug_log( "Skipping URL extraction for non-text file: " . $static_page->content_type );
 		}
 
 		if ( $follow_urls ) {
@@ -305,6 +309,33 @@ class Fetch_Urls_Task extends Task {
 		}
 
 		$static_page->save();
+	}
+
+	/**
+	 * Only text-like files can contain URLs that should be extracted or replaced.
+	 *
+	 * @param \Simply_Static\Page $static_page Record to inspect.
+	 *
+	 * @return bool
+	 */
+	protected function can_extract_urls_from_static_page( $static_page ) {
+		$file_path = isset( $static_page->file_path ) ? (string) $static_page->file_path : '';
+
+		if (
+			$static_page->is_type( 'html' ) ||
+			$static_page->is_type( 'css' ) ||
+			$static_page->is_type( 'xml' ) ||
+			$static_page->is_type( 'xsl' ) ||
+			$static_page->is_type( 'json' )
+		) {
+			return true;
+		}
+
+		if ( '' !== $file_path && substr( $file_path, -4 ) === '.css' ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/tasks/traits/trait-ss-can-process-pages.php
+++ b/src/tasks/traits/trait-ss-can-process-pages.php
@@ -191,6 +191,15 @@ trait canProcessPages {
 				) );
 				$static_page->set_error_message( $e->getMessage() );
 				$static_page->save();
+			} catch ( \Throwable $e ) {
+				Util::debug_log( 'Page URL: ' . $static_page->url . ' not being processed. Error: ' . $e->getMessage() );
+				// Reset the claim so the page can be retried on next iteration.
+				$wpdb->query( $wpdb->prepare(
+					"UPDATE {$table_name} SET {$this->processing_column} = NULL WHERE id = %d",
+					$static_page->id
+				) );
+				$static_page->set_error_message( $e->getMessage() );
+				$static_page->save();
 			}
 		}
 


### PR DESCRIPTION
Skips URL extraction and replacement for non-text responses while keeping HTML, CSS, XML, XSL, JSON, and CSS extension fallback processing intact. Expands binary detection and local MIME mapping for common audio and video files so extensionless media is not treated like text. Adds model __isset() support for magic fields and resets page claims when Throwable errors occur so failed pages can be retried instead of leaving exports stuck.