### PR TITLE
Fix wp-includes exports for subdirectory installs

### DIFF
--- a/src/crawler/class-ss-wp-includes-crawler.php
+++ b/src/crawler/class-ss-wp-includes-crawler.php
@@ -48,25 +48,41 @@ class Wp_Includes_Crawler extends Crawler {
 	 * @return array List of wp-includes file URLs
 	 */
 	public function detect(): array {
-		$site_url = \Simply_Static\Util::origin_url();
-		$wp_path  = trailingslashit( ABSPATH );
-		$inc_path = wp_parse_url( includes_url(), PHP_URL_PATH );
-		$wp_inc   = '/' . untrailingslashit( ltrim( $inc_path, '/' ) ) . '/';
+		$wp_inc       = defined( 'WPINC' ) ? WPINC : 'wp-includes';
+		$origin_url   = \Simply_Static\Util::origin_url();
+		$origin_parts = wp_parse_url( $origin_url );
+		$inc_path     = wp_parse_url( includes_url(), PHP_URL_PATH );
+		$inc_path     = is_string( $inc_path ) && '' !== $inc_path ? $inc_path : '/' . $wp_inc;
+		$origin_path  = isset( $origin_parts['path'] ) ? '/' . trim( $origin_parts['path'], '/' ) : '';
+
+		if ( '' !== $origin_path && '/' !== $origin_path ) {
+			$inc_path = '/' . ltrim( $inc_path, '/' );
+
+			if ( $inc_path === $origin_path ) {
+				$inc_path = '/';
+			} elseif ( 0 === strpos( $inc_path . '/', trailingslashit( $origin_path ) ) ) {
+				$inc_path = substr( $inc_path, strlen( $origin_path ) );
+			}
+		}
+
+		$includes_url = trailingslashit( \Simply_Static\Util::safe_join_url( $origin_url, $inc_path ) );
+		$wp_inc_dir   = trailingslashit( ABSPATH . $wp_inc );
 
 		$urls = [
-			$site_url . $wp_inc . 'js/jquery/jquery.min.js',
-			$site_url . $wp_inc . 'js/wp-emoji-release.min.js',
+			\Simply_Static\Util::safe_join_url( $includes_url, 'js/jquery/jquery.min.js' ),
+			\Simply_Static\Util::safe_join_url( $includes_url, 'js/wp-emoji-release.min.js' ),
 		];
 
 		if ( get_option( 'thread_comments' ) ) {
-			$urls[] = $site_url . $wp_inc . 'js/comment-reply.min.js';
+			$urls[] = \Simply_Static\Util::safe_join_url( $includes_url, 'js/comment-reply.min.js' );
 		}
 
 		$dirs = [ 'css/', 'js/', 'fonts/', 'images/', 'blocks/' ];
 		$exts = [ 'css', 'js', 'json', 'woff', 'woff2', 'ttf', 'eot', 'otf', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'ico' ];
 
 		foreach ( $dirs as $dir ) {
-			$full_path = $wp_path . ltrim( $wp_inc, '/' ) . $dir;
+			$full_path = $wp_inc_dir . $dir;
+			$dir_url   = \Simply_Static\Util::safe_join_url( $includes_url, $dir );
 			if ( ! is_dir( $full_path ) ) continue;
 
 			$it = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $full_path, \RecursiveDirectoryIterator::SKIP_DOTS ) );
@@ -74,7 +90,7 @@ class Wp_Includes_Crawler extends Crawler {
 				if ( $file->isDir() ) continue;
 				$rel = \Simply_Static\Util::safe_relative_path( $full_path, $file->getPathname() );
 				if ( in_array( strtolower( pathinfo( $rel, PATHINFO_EXTENSION ) ), $exts, true ) ) {
-					$urls[] = \Simply_Static\Util::safe_join_url( $site_url . $wp_inc . $dir, $rel );
+					$urls[] = \Simply_Static\Util::safe_join_url( $dir_url, $rel );
 				}
 			}
 		}


### PR DESCRIPTION
Updates the wp-includes crawler to build public asset URLs from the configured origin URL and the WordPress includes URL path. This prevents subdirectory installations from exporting duplicated or incorrect wp-includes paths while still scanning the local WPINC directory.\n\nValidation: php -l src/crawler/class-ss-wp-includes-crawler.php