### PR TITLE
Fix origin URL replacement for WP asset paths

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -644,10 +644,10 @@ class Url_Extractor {
 		$response_body = $this->preserve_xmp_tags( $response_body );
 
 		// replace wp_json_encode'd urls, as used by WP's `concatemoji`
-		$response_body = str_replace( addcslashes( Util::origin_url(), '/' ), addcslashes( $destination_url, '/' ), $response_body );
+		$response_body = preg_replace( '/' . Util::json_escaped_origin_url_pattern() . '/i', addcslashes( untrailingslashit( $destination_url ), '/' ), $response_body );
 
 		// replace encoded URLs, as found in query params
-		$response_body = preg_replace( '/(https?%3A)?%2F%2F' . addcslashes( urlencode( Util::origin_host() ), '.' ) . '/i', urlencode( $destination_url ), $response_body );
+		$response_body = preg_replace( '/(https?%3A)?%2F%2F' . Util::origin_host_pattern( true ) . '/i', urlencode( $destination_url ), $response_body );
 
 		// Restore preserved <xmp> tags
 		$response_body = $this->restore_xmp_tags( $response_body );
@@ -676,11 +676,11 @@ class Url_Extractor {
 		$content = $this->preserve_xmp_tags( $content );
 
 		// replace any instance of the origin url, whether it starts with https://, http://, or //.
-		$content = preg_replace( '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', $destination_url, $content );
+		$content = preg_replace( '/(https?:)?\/\/' . Util::origin_host_pattern() . '/i', $destination_url, $content );
 
 		// replace wp_json_encode'd urls, as used by WP's `concatemoji`.
 		// e.g. {"concatemoji":"http:\/\/www.example.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.6.1"}.
-		$content = str_replace( addcslashes( untrailingslashit( Util::origin_url() ), '/' ), addcslashes( untrailingslashit( $destination_url ), '/' ), $content );
+		$content = preg_replace( '/' . Util::json_escaped_origin_url_pattern() . '/i', addcslashes( untrailingslashit( $destination_url ), '/' ), $content );
 
 		// Restore preserved <xmp> tags
 		$content = $this->restore_xmp_tags( $content );
@@ -1664,17 +1664,17 @@ class Url_Extractor {
 
 		// Replace URLs in the script content
 		// First, replace protocol-relative URLs (//example.com)
-		$text = preg_replace( '/(["\'(])\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', '$1' . $convert_to, $decoded_text );
+		$text = preg_replace( '/(["\'(])\/\/' . Util::origin_host_pattern() . '/i', '$1' . $convert_to, $decoded_text );
 
 		// Then replace absolute URLs (http://example.com or https://example.com)
-		$text = preg_replace( '/(["\'(])(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', '$1' . $convert_to, $text );
+		$text = preg_replace( '/(["\'(])(https?:)?\/\/' . Util::origin_host_pattern() . '/i', '$1' . $convert_to, $text );
 
 		// Also replace JSON-encoded URLs
-		$text = str_replace( addcslashes( untrailingslashit( Util::origin_url() ), '/' ), addcslashes( untrailingslashit( $convert_to ), '/' ), $text );
+		$text = preg_replace( '/' . Util::json_escaped_origin_url_pattern() . '/i', addcslashes( untrailingslashit( $convert_to ), '/' ), $text );
 
 		// Replace URLs in sourceURL and sourceMappingURL comments (used for debugging)
 		// Handles both //# and //@ formats (the latter is deprecated but still used)
-		$text = preg_replace( '/(\/\/[#@]\s*(?:sourceURL|sourceMappingURL)\s*=\s*)(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', '$1' . $convert_to, $text );
+		$text = preg_replace( '/(\/\/[#@]\s*(?:sourceURL|sourceMappingURL)\s*=\s*)(https?:)?\/\/' . Util::origin_host_pattern() . '/i', '$1' . $convert_to, $text );
 
 		return $text;
 	}

--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -789,21 +789,8 @@ class Util {
 			return empty( $sitemap_placeholders ) ? $content : strtr( $content, $sitemap_placeholders );
 		}
 
-		$origin_base  = trailingslashit( self::origin_url() );
-		$origin_http  = set_url_scheme( $origin_base, 'http' );
-		$origin_https = set_url_scheme( $origin_base, 'https' );
-		$origin_proto = preg_replace( '#^https?:#i', '', $origin_https );
-		$search       = [
-			untrailingslashit( rtrim( $origin_http, '/' ) ),
-			untrailingslashit( rtrim( $origin_https, '/' ) ),
-			untrailingslashit( rtrim( $origin_proto, '/' ) ),
-		];
-		$content    = str_replace( $search, $destination_base, $content );
-
-		$origin_host  = self::origin_host();
-		$host_no_port = preg_replace( '/:\\d+$/', '', (string) $origin_host );
-		$pattern      = '/(?:https?:)?\\/\\/' . preg_quote( $host_no_port, '/' ) . '(?::\\d+)?/i';
-		$replaced     = preg_replace( $pattern, $destination_base, $content );
+		$pattern  = '/(?:https?:)?\\/\\/' . self::origin_host_pattern( false, true ) . '/i';
+		$replaced = preg_replace( $pattern, $destination_base, $content );
 		if ( is_string( $replaced ) ) {
 			$content = $replaced;
 		}
@@ -827,6 +814,59 @@ class Util {
 	 */
 	public static function origin_host() {
 		return untrailingslashit( self::strip_protocol_from_url( self::origin_url() ) );
+	}
+
+	/**
+	 * Build a regex-safe origin host/path pattern with a URL segment boundary.
+	 *
+	 * origin_host() may include a subdirectory (for example example.com/wp).
+	 * Without a boundary, raw replacements can treat /wp-includes as though it
+	 * started with the /wp base and leave broken suffixes like -includes.
+	 *
+	 * @param bool $encoded Whether the target text is URL-encoded.
+	 * @param bool $allow_port Whether to allow any port when origin_url has none.
+	 *
+	 * @return string Regex fragment.
+	 */
+	public static function origin_host_pattern( $encoded = false, $allow_port = false ) {
+		$origin_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( self::origin_url() ) : parse_url( self::origin_url() );
+
+		if ( ! is_array( $origin_parts ) || empty( $origin_parts['host'] ) ) {
+			$origin_host = self::origin_host();
+			$pattern     = preg_quote( $encoded ? urlencode( $origin_host ) : $origin_host, '/' );
+
+			return $pattern . ( $encoded ? '(?=$|%2F|%3F|%23)' : '(?=$|[\/?#])' );
+		}
+
+		$host = (string) $origin_parts['host'];
+		$path = isset( $origin_parts['path'] ) ? untrailingslashit( (string) $origin_parts['path'] ) : '';
+
+		if ( $encoded ) {
+			$port = isset( $origin_parts['port'] ) ? ':' . $origin_parts['port'] : '';
+
+			return preg_quote( urlencode( $host . $port . $path ), '/' ) . '(?=$|%2F|%3F|%23)';
+		}
+
+		$port_pattern = '';
+		if ( isset( $origin_parts['port'] ) ) {
+			$port_pattern = preg_quote( ':' . $origin_parts['port'], '/' );
+		} elseif ( $allow_port ) {
+			$port_pattern = '(?::\d+)?';
+		}
+
+		return preg_quote( $host, '/' ) . $port_pattern . preg_quote( $path, '/' ) . '(?=$|[\/?#])';
+	}
+
+	/**
+	 * Build a regex-safe JSON-escaped origin URL pattern with a path boundary.
+	 *
+	 * WordPress often writes URLs in JSON as https:\/\/example.com\/wp\/path.
+	 * A boundary prevents /wp from partially matching /wp-includes.
+	 *
+	 * @return string Regex fragment.
+	 */
+	public static function json_escaped_origin_url_pattern() {
+		return preg_quote( addcslashes( untrailingslashit( self::origin_url() ), '/' ), '/' ) . '(?=$|\\\\\/|[?#])';
 	}
 
 	/**
@@ -881,6 +921,7 @@ class Util {
 
 		$url_host = strtolower( preg_replace( '/:\d+$/', '', (string) $url_parts['host'] ) );
 		$url_path = isset( $url_parts['path'] ) ? untrailingslashit( $url_parts['path'] ) : '';
+		$same_host = false;
 
 		foreach ( self::local_url_bases() as $base ) {
 			$base_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $base ) : parse_url( $base );
@@ -893,13 +934,53 @@ class Util {
 				continue;
 			}
 
+			$same_host = true;
+
 			$base_path = isset( $base_parts['path'] ) ? untrailingslashit( $base_parts['path'] ) : '';
 			if ( '' === $base_path || '/' === $base_path || $url_path === $base_path || strpos( $url_path . '/', trailingslashit( $base_path ) ) === 0 ) {
 				return $base;
 			}
 		}
 
+		if ( $same_host && self::is_root_wordpress_asset_path( $url_path ) ) {
+			$scheme = isset( $url_parts['scheme'] ) ? $url_parts['scheme'] : self::origin_scheme();
+			$port   = isset( $url_parts['port'] ) ? ':' . $url_parts['port'] : '';
+
+			return $scheme . '://' . $url_parts['host'] . $port;
+		}
+
 		return null;
+	}
+
+	/**
+	 * Check whether a same-host root path points at WordPress asset directories.
+	 *
+	 * @param string $path URL path.
+	 *
+	 * @return bool
+	 */
+	private static function is_root_wordpress_asset_path( $path ) {
+		if ( ! is_string( $path ) || '' === $path || '/' === $path ) {
+			return false;
+		}
+
+		$segments = explode( '/', trim( $path, '/' ) );
+		if ( empty( $segments[0] ) ) {
+			return false;
+		}
+
+		$options    = Options::instance();
+		$asset_dirs = array(
+			'wp-admin',
+			'wp-content',
+			'wp-includes',
+			self::get_hide_wp_option( $options, 'wp_content_directory', 'wp_content_folder', 'wp-content' ),
+			self::get_hide_wp_option( $options, 'wp_includes_directory', 'wp_includes_folder', 'wp-includes' ),
+		);
+
+		$asset_dirs = array_values( array_unique( array_filter( array_map( 'strval', $asset_dirs ) ) ) );
+
+		return in_array( $segments[0], $asset_dirs, true );
 	}
 
 	/**
@@ -1162,7 +1243,7 @@ class Util {
 		if ( strpos( $extracted_url, '//' ) === 0 ) {
 
 			// if this is a local URL, add the protocol to the URL
-			if ( stripos( $extracted_url, '//' . self::origin_host() ) === 0 ) {
+			if ( preg_match( '/^\/\/' . self::origin_host_pattern() . '/i', $extracted_url ) ) {
 				$extracted_url = self::origin_scheme() . ':' . $extracted_url;
 			}
 
@@ -1322,7 +1403,7 @@ class Util {
 
 		// Fallback: origin_host() may include a subdirectory; strip only once at the start.
 		$no_scheme = self::strip_protocol_from_url( $url );
-		$pattern   = '/^' . preg_quote( self::origin_host(), '/' ) . '/';
+		$pattern   = '/^' . self::origin_host_pattern() . '/';
 		$no_host   = preg_replace( $pattern, '', $no_scheme, 1 );
 
 		return '/' . ltrim( $no_host, '/' );

--- a/src/handlers/class-ss-aio-seo-sitemap-handler.php
+++ b/src/handlers/class-ss-aio-seo-sitemap-handler.php
@@ -229,7 +229,7 @@ class AIO_SEO_Sitemap_Handler extends Page_Handler {
             return $xml;
         }
         $dest = rtrim( $destination_url, '/' );
-        $pattern = '/(?:(https?:)?\\/\\/)' . preg_quote( $origin_host, '/' ) . '/i';
+        $pattern = '/(?:(https?:)?\\/\\/)' . Util::origin_host_pattern() . '/i';
         return preg_replace( $pattern, $dest, $xml );
     }
 }

--- a/src/handlers/class-ss-rank-math-sitemap-handler.php
+++ b/src/handlers/class-ss-rank-math-sitemap-handler.php
@@ -253,7 +253,7 @@ class Rank_Math_Sitemap_Handler extends Page_Handler {
             return $xml;
         }
         $dest = rtrim( $destination_url, '/' );
-        $pattern = '/(?:(https?:)?\\/\\/)' . preg_quote( $origin_host, '/' ) . '/i';
+        $pattern = '/(?:(https?:)?\\/\\/)' . Util::origin_host_pattern() . '/i';
         return preg_replace( $pattern, $dest, $xml );
     }
 }

--- a/src/handlers/class-ss-seopress-sitemap-handler.php
+++ b/src/handlers/class-ss-seopress-sitemap-handler.php
@@ -261,7 +261,7 @@ class SEOPress_Sitemap_Handler extends Page_Handler {
             return $xml;
         }
         $dest = rtrim( $destination_url, '/' );
-        $pattern = '/(?:(https?:)?\/\/)' . preg_quote( $origin_host, '/' ) . '/i';
+        $pattern = '/(?:(https?:)?\/\/)' . Util::origin_host_pattern() . '/i';
         return preg_replace( $pattern, $dest, $xml );
     }
 

--- a/src/handlers/class-ss-yoast-sitemap-handler.php
+++ b/src/handlers/class-ss-yoast-sitemap-handler.php
@@ -209,7 +209,7 @@ class Yoast_Sitemap_Handler extends Page_Handler {
             return $xml;
         }
         $dest = rtrim( $destination_url, '/' );
-        $pattern = '/(?:(https?:)?\/\/)' . preg_quote( $origin_host, '/' ) . '/i';
+        $pattern = '/(?:(https?:)?\/\/)' . Util::origin_host_pattern() . '/i';
         return preg_replace( $pattern, $dest, $xml );
     }
 }

--- a/src/integrations/class-ss-divi-integration.php
+++ b/src/integrations/class-ss-divi-integration.php
@@ -111,7 +111,7 @@ class Divi_Integration extends Integration {
 					}
 
 					$updated = preg_replace(
-						'/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i',
+						'/(https?:)?\/\/' . Util::origin_host_pattern() . '/i',
 						$destination_url,
 						$decoded
 					);

--- a/src/integrations/class-ss-elementor-integration.php
+++ b/src/integrations/class-ss-elementor-integration.php
@@ -155,11 +155,11 @@ class Elementor_Integration extends Integration {
 		$string = preg_replace_callback( $pattern, array( $this, 'replace_urls' ), $string );
 
 		// replace any instance of the origin url, whether it starts with https://, http://, or //.
-		$string = preg_replace( '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', $destination_url, $string );
+		$string = preg_replace( '/(https?:)?\/\/' . Util::origin_host_pattern() . '/i', $destination_url, $string );
 
 		// replace wp_json_encode'd urls, as used by WP's `concatemoji`.
 		// e.g. {"concatemoji":"http:\/\/www.example.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.6.1"}.
-		$string = str_replace( addcslashes( untrailingslashit( Util::origin_url() ), '/' ), addcslashes( untrailingslashit( $destination_url ), '/' ), $string );
+		$string = preg_replace( '/' . Util::json_escaped_origin_url_pattern() . '/i', addcslashes( untrailingslashit( $destination_url ), '/' ), $string );
 
 
 		return $string;

--- a/src/integrations/class-ss-rank-math-integration.php
+++ b/src/integrations/class-ss-rank-math-integration.php
@@ -349,7 +349,7 @@ class Rank_Math_Integration extends Integration {
 		if ( $scripts ) {
 			foreach ( $scripts as $script ) {
 				$decoded_text = html_entity_decode( $script->nodeValue, ENT_NOQUOTES );
-				$text = preg_replace( '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', $options->get_destination_url(), $decoded_text );
+				$text = preg_replace( '/(https?:)?\/\/' . Util::origin_host_pattern() . '/i', $options->get_destination_url(), $decoded_text );
 				$script->nodeValue = $text;
 			}
 		}

--- a/src/integrations/class-ss-yoast-integration.php
+++ b/src/integrations/class-ss-yoast-integration.php
@@ -199,7 +199,7 @@ class Yoast_Integration extends Integration {
 		if ( $scripts ) {
 			foreach ( $scripts as $script ) {
 				$decoded_text = html_entity_decode( $script->nodeValue, ENT_NOQUOTES );
-				$text = preg_replace( '/(https?:)?\/\/' . addcslashes( Util::origin_host(), '/' ) . '/i', $options->get_destination_url(), $decoded_text );
+				$text = preg_replace( '/(https?:)?\/\/' . Util::origin_host_pattern() . '/i', $options->get_destination_url(), $decoded_text );
 				$script->nodeValue = $text;
 			}
 		}


### PR DESCRIPTION
## Summary
- Add boundary-aware origin host and JSON-escaped URL regex helpers.
- Use the helpers across URL extraction, sitemap handlers, and SEO/page-builder integrations so subdirectory installs do not partially replace paths like /wp-includes.
- Treat same-host root WordPress asset paths as local for export handling.

## Testing
- php -l on all changed PHP files
- git diff --check