### PR TITLE
Add search results page export toggle

### DIFF
--- a/src/admin/inc/class-ss-admin-rest.php
+++ b/src/admin/inc/class-ss-admin-rest.php
@@ -1158,6 +1158,7 @@ class Admin_Rest {
             's3_access_secret'              => '',
             's3_bucket'                     => '',
             's3_subdirectory'               => '',
+            'use_search_results_page'       => true,
             'fix_cors'                      => 'allowed_http_origins',
             // (the full list continues in Admin_Settings; retain same defaults here)
         );

--- a/src/class-ss-upgrade-handler.php
+++ b/src/class-ss-upgrade-handler.php
@@ -122,6 +122,7 @@ class Upgrade_Handler {
 			'use_comments'                  => false,
 			'comment_redirect'              => '',
 			'use_search'                    => false,
+			'use_search_results_page'       => true,
 			'search_type'                   => 'fuse',
 			'search_index_title'            => 'title',
 			'search_index_content'          => 'body',

--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -444,34 +444,37 @@ class Url_Fetcher {
 		// Prevent query-string URLs from overwriting base paths by placing them in a deterministic subdirectory based on the query string.
 		// Exception: native WordPress search (query parameter `s`) should NOT use a hash subdirectory.
 		// Assets (JS, CSS, fonts) should ALSO NOT use a hash subdirectory, as their query strings are usually just for cache busting.
-  if ( ! empty( $url_parts['query'] ) && ! Util::is_local_asset_url( $static_page->url ) ) {
-            $relative_file_dir = Util::add_trailing_directory_separator( $relative_file_dir );
-            $use_hash_dir      = true;
-            parse_str( (string) $url_parts['query'], $qs_args );
+		if ( ! empty( $url_parts['query'] ) && ! Util::is_local_asset_url( $static_page->url ) ) {
+			$relative_file_dir = Util::add_trailing_directory_separator( $relative_file_dir );
+			$use_hash_dir      = true;
+			parse_str( (string) $url_parts['query'], $qs_args );
 
-            // Global gate: when the Search Results Page feature is disabled, do not create any __qs directories at all.
-            $use_results_page = Options::instance()->get( 'use_search_results_page' );
-            if ( ! isset( $use_results_page ) ) {
-                $use_results_page = true; // default back-compat
-            }
-            /**
-             * Filter whether Simply Static should use the dedicated Search Results Page export (`__qs`) for query-string URLs.
-             * Returning false will skip creating any `__qs` directory/files for all query-string URLs entirely.
-             *
-             * @param bool $use_results_page Whether to use the Search Results Page export. Default comes from settings (true).
-             * @param array<string,mixed> $qs_args Parsed query-string arguments.
-             * @param \Simply_Static\Page $static_page The current static page instance.
-             */
-            $use_results_page = apply_filters( 'ss_use_search_results_page', (bool) $use_results_page, $qs_args, $static_page );
-            if ( false === $use_results_page ) {
-                Util::debug_log( '[SS][SEARCH_QS] Skipping __qs/ creation due to setting being disabled: ' . $static_page->url );
-                return null; // do not create a file for this query-string URL
-            }
+			// Global gate: when search or the Search Results Page feature is disabled, do not create any __qs directories.
+			$use_search       = Options::instance()->get( 'use_search' );
+			$use_results_page = Options::instance()->get( 'use_search_results_page' );
+			if ( null === $use_results_page ) {
+				$use_results_page = true; // default back-compat when search is enabled
+			}
+			$use_results_page = (bool) $use_search && (bool) $use_results_page;
 
-            // Exception: native WordPress search (query parameter `s`) should NOT use a hash subdirectory.
-            if ( is_array( $qs_args ) && array_key_exists( 's', $qs_args ) ) {
-                $use_hash_dir = false;
-            }
+			/**
+			 * Filter whether Simply Static should use the dedicated Search Results Page export (`__qs`) for query-string URLs.
+			 * Returning false will skip creating any `__qs` directory/files for query-string URLs entirely.
+			 *
+			 * @param bool $use_results_page Whether to use the Search Results Page export. Default requires search to be enabled.
+			 * @param array<string,mixed> $qs_args Parsed query-string arguments.
+			 * @param \Simply_Static\Page $static_page The current static page instance.
+			 */
+			$use_results_page = apply_filters( 'ss_use_search_results_page', $use_results_page, $qs_args, $static_page );
+			if ( false === $use_results_page ) {
+				Util::debug_log( '[SS][SEARCH_QS] Skipping __qs/ creation due to search/results page setting being disabled: ' . $static_page->url );
+				return null; // do not create a file for this query-string URL
+			}
+
+			// Exception: native WordPress search (query parameter `s`) should NOT use a hash subdirectory.
+			if ( is_array( $qs_args ) && array_key_exists( 's', $qs_args ) ) {
+				$use_hash_dir = false;
+			}
 			/**
 			 * Filter whether Simply Static should use a hash directory for query-string URLs.
 			 *

--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -542,6 +542,21 @@ class Util {
 		$excluded = array( '.php' );
 		$opts     = Options::instance();
 
+		$use_search              = (bool) $opts->get( 'use_search' );
+		$use_search_results_page = $opts->get( 'use_search_results_page' );
+		if ( null === $use_search_results_page ) {
+			$use_search_results_page = true;
+		}
+
+		if ( ! $use_search || ! $use_search_results_page ) {
+			$url_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url );
+			if ( ! empty( $url_parts['query'] ) && ! self::is_local_asset_url( $url ) ) {
+				self::debug_log( sprintf( 'Excluding URL "%s" - matched built-in rule: query-string URL (search results page is disabled)', $url ) );
+
+				return true;
+			}
+		}
+
 		// Exclude debug files (.log, .txt) but not robots.txt, llms.txt, _redirects, or _headers
 		if ( preg_match( '/\.(log|txt)$/i', $url ) && strpos( $url, 'debug' ) !== false && strpos( $url, 'robots.txt' ) === false && strpos( $url, 'llms.txt' ) === false && strpos( $url, '_redirects' ) === false && strpos( $url, '_headers' ) === false ) {
 			self::debug_log( sprintf( 'Excluding URL "%s" — matched built-in rule: debug log file pattern', $url ) );


### PR DESCRIPTION
## Summary
- Add the default use_search_results_page setting for installs and resets.
- Gate __qs query-string export creation on search and the search results page toggle.
- Exclude non-asset query-string URLs when search/results page export is disabled.

## Testing
- git diff --check HEAD