### PR TITLE
Add deploy manifest tracking

### DIFF
--- a/src/admin/inc/class-ss-admin-rest.php
+++ b/src/admin/inc/class-ss-admin-rest.php
@@ -281,6 +281,54 @@ class Admin_Rest {
             },
         ) );
 
+        register_rest_route( 'simplystatic/v1', '/exports', array(
+            'methods'             => 'GET',
+            'callback'            => [ $this, 'get_deploy_manifests' ],
+            'permission_callback' => function () {
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'activity-log' ) );
+            },
+        ) );
+
+        register_rest_route( 'simplystatic/v1', '/exports/latest', array(
+            'methods'             => 'GET',
+            'callback'            => [ $this, 'get_latest_deploy_manifest' ],
+            'permission_callback' => function () {
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'activity-log' ) );
+            },
+        ) );
+
+        register_rest_route( 'simplystatic/v1', '/exports/(?P<export_id>[a-zA-Z0-9][a-zA-Z0-9_-]{7,79})', array(
+            'methods'             => 'GET',
+            'callback'            => [ $this, 'get_deploy_manifest' ],
+            'permission_callback' => function () {
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'activity-log' ) );
+            },
+        ) );
+
+        register_rest_route( 'simplystatic/v1', '/exports/(?P<export_id>[a-zA-Z0-9][a-zA-Z0-9_-]{7,79})/urls', array(
+            'methods'             => 'GET',
+            'callback'            => [ $this, 'get_deploy_manifest_urls' ],
+            'permission_callback' => function () {
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'activity-log' ) );
+            },
+        ) );
+
+        register_rest_route( 'simplystatic/v1', '/exports/(?P<export_id>[a-zA-Z0-9][a-zA-Z0-9_-]{7,79})/files', array(
+            'methods'             => 'GET',
+            'callback'            => [ $this, 'get_deploy_manifest_files' ],
+            'permission_callback' => function () {
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'activity-log' ) );
+            },
+        ) );
+
+        register_rest_route( 'simplystatic/v1', '/exports/(?P<export_id>[a-zA-Z0-9][a-zA-Z0-9_-]{7,79})/warnings', array(
+            'methods'             => 'GET',
+            'callback'            => [ $this, 'get_deploy_manifest_warnings' ],
+            'permission_callback' => function () {
+                return current_user_can( apply_filters( 'ss_user_capability', 'manage_options', 'activity-log' ) );
+            },
+        ) );
+
         register_rest_route( 'simplystatic/v1', '/start-export', array(
             'methods'             => 'POST',
             'callback'            => [ $this, 'start_export' ],
@@ -1333,6 +1381,71 @@ class Admin_Rest {
         }
 
         return json_encode( [ 'status' => 200, 'data' => $export_log ] );
+    }
+
+    /** Deploy manifest summaries */
+    public function get_deploy_manifests( $request ) {
+        $params   = $request->get_params();
+        $page     = ! empty( $params['page'] ) ? absint( $params['page'] ) : 1;
+        $per_page = ! empty( $params['per_page'] ) ? absint( $params['per_page'] ) : 20;
+
+        return rest_ensure_response( Deploy_Manifest_Service::get_instance()->get_exports( $page, $per_page ) );
+    }
+
+    /** Latest deploy manifest */
+    public function get_latest_deploy_manifest() {
+        $manifest = Deploy_Manifest_Service::get_instance()->get_latest_manifest();
+
+        if ( empty( $manifest ) ) {
+            return new \WP_Error( 'ss_manifest_not_found', __( 'No deploy manifest available.', 'simply-static' ), array( 'status' => 404 ) );
+        }
+
+        return rest_ensure_response( $manifest );
+    }
+
+    /** Deploy manifest by ID */
+    public function get_deploy_manifest( $request ) {
+        $deploy_id = sanitize_text_field( $request->get_param( 'export_id' ) );
+        $manifest  = Deploy_Manifest_Service::get_instance()->get_manifest( $deploy_id );
+
+        if ( empty( $manifest ) ) {
+            return new \WP_Error( 'ss_manifest_not_found', __( 'Deploy manifest not found.', 'simply-static' ), array( 'status' => 404 ) );
+        }
+
+        return rest_ensure_response( $manifest );
+    }
+
+    /** Deploy manifest URL records */
+    public function get_deploy_manifest_urls( $request ) {
+        $params    = $request->get_params();
+        $deploy_id = sanitize_text_field( $request->get_param( 'export_id' ) );
+
+        return rest_ensure_response(
+            Deploy_Manifest_Service::get_instance()->get_manifest_urls(
+                $deploy_id,
+                array(
+                    'page'     => ! empty( $params['page'] ) ? absint( $params['page'] ) : 1,
+                    'per_page' => ! empty( $params['per_page'] ) ? absint( $params['per_page'] ) : 100,
+                    'status'   => ! empty( $params['status'] ) ? sanitize_text_field( $params['status'] ) : '',
+                    'type'     => ! empty( $params['type'] ) ? sanitize_text_field( $params['type'] ) : '',
+                    'search'   => ! empty( $params['search'] ) ? sanitize_text_field( $params['search'] ) : '',
+                )
+            )
+        );
+    }
+
+    /** Deploy manifest file records */
+    public function get_deploy_manifest_files( $request ) {
+        $deploy_id = sanitize_text_field( $request->get_param( 'export_id' ) );
+
+        return rest_ensure_response( Deploy_Manifest_Service::get_instance()->get_manifest_files( $deploy_id ) );
+    }
+
+    /** Deploy manifest warnings */
+    public function get_deploy_manifest_warnings( $request ) {
+        $deploy_id = sanitize_text_field( $request->get_param( 'export_id' ) );
+
+        return rest_ensure_response( Deploy_Manifest_Service::get_instance()->get_manifest_warnings( $deploy_id ) );
     }
 
     /**

--- a/src/class-ss-archive-creation-job.php
+++ b/src/class-ss-archive-creation-job.php
@@ -155,6 +155,7 @@ class Archive_Creation_Job extends Background_Process {
 
 			$this->options
 				->set( 'archive_status_messages', array() )
+				->set( 'archive_deploy_id', function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( 'deploy_', true ) )
 				->set( 'archive_start_time', Util::formatted_datetime() )
 				->set( 'archive_end_time', null )
 				->set( 'generate_type', $type )
@@ -560,6 +561,7 @@ class Archive_Creation_Job extends Background_Process {
 		Util::debug_log( $exception );
 
 		$message = sprintf( __( "An exception occurred: %s", 'simply-static' ), $exception->getMessage() );
+		$this->options->set( 'archive_end_time', Util::formatted_datetime() );
 		$this->save_status_message( $message, 'error' );
 		do_action( 'ss_completed', 'exception', $message );
 
@@ -578,6 +580,7 @@ class Archive_Creation_Job extends Background_Process {
 		Util::debug_log( $wp_error );
 
 		$message = sprintf( __( "An error occurred: %s", 'simply-static' ), $wp_error->get_error_message() );
+		$this->options->set( 'archive_end_time', Util::formatted_datetime() );
 		$this->save_status_message( $message, 'error' );
 		do_action( 'ss_completed', 'error', $message );
 

--- a/src/class-ss-deploy-manifest-service.php
+++ b/src/class-ss-deploy-manifest-service.php
@@ -1,0 +1,1048 @@
+<?php
+
+namespace Simply_Static;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds, stores, and exposes deploy manifests from Simply Static export data.
+ */
+class Deploy_Manifest_Service {
+
+	const MANIFEST_VERSION = '1.0';
+	const SCHEMA_VERSION   = '1';
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Deploy_Manifest_Service|null
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Options instance.
+	 *
+	 * @var Options
+	 */
+	protected $options;
+
+	/**
+	 * Return singleton instance.
+	 *
+	 * @return Deploy_Manifest_Service
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register export hooks.
+	 */
+	protected function __construct() {
+		$this->options = Options::instance();
+		add_action( 'ss_completed', array( $this, 'store_current_manifest' ), 20, 2 );
+	}
+
+	/**
+	 * Ensure manifest tables exist.
+	 *
+	 * @return void
+	 */
+	public static function create_or_update_tables() {
+		Deploy_Manifest::create_or_update_table();
+		Deploy_Manifest_Url::create_or_update_table();
+	}
+
+	/**
+	 * Store a manifest for the current export.
+	 *
+	 * @param string $result Export result from ss_completed.
+	 * @param string $message Optional failure message.
+	 *
+	 * @return array|null
+	 */
+	public function store_current_manifest( $result = 'success', $message = '' ) {
+		try {
+			$manifest = $this->build_current_manifest( $result, $message );
+			$this->persist_manifest( $manifest );
+
+			return $manifest;
+		} catch ( \Throwable $e ) {
+			Util::debug_log( 'Unable to store deploy manifest: ' . $e->getMessage() );
+			return null;
+		}
+	}
+
+	/**
+	 * Build the current manifest from Simply Static page records.
+	 *
+	 * @param string $result Export result.
+	 * @param string $message Optional failure message.
+	 *
+	 * @return array
+	 */
+	public function build_current_manifest( $result = 'success', $message = '' ) {
+		$deploy_id = $this->options->get( 'archive_deploy_id' );
+
+		if ( empty( $deploy_id ) ) {
+			$deploy_id = $this->new_deploy_id();
+			$this->options->set( 'archive_deploy_id', $deploy_id )->save();
+		}
+
+		$started_at  = $this->options->get( 'archive_start_time' );
+		$finished_at = $this->options->get( 'archive_end_time' );
+		$status      = $this->normalize_status( $result );
+		$records     = $this->build_url_records();
+		$counts      = $this->count_url_records( $records );
+		$root_files  = array_values( array_filter( $records, array( $this, 'is_root_record' ) ) );
+		$warnings    = $this->collect_manifest_messages( $records, 'warnings' );
+		$errors      = $this->collect_manifest_messages( $records, 'errors' );
+
+		if ( ! empty( $message ) && 'success' !== $status ) {
+			$errors[] = array(
+				'code'    => $status,
+				'message' => wp_strip_all_tags( (string) $message ),
+			);
+		}
+
+		$duration = null;
+		if ( ! empty( $started_at ) && ! empty( $finished_at ) ) {
+			$duration = max( 0, strtotime( $finished_at ) - strtotime( $started_at ) );
+		}
+
+		$manifest = array(
+			'manifest_version' => self::MANIFEST_VERSION,
+			'deploy_id'        => $deploy_id,
+			'site_id'          => (string) get_current_blog_id(),
+			'environment_id'   => null,
+			'domain'           => $this->get_domain(),
+			'mount_path'       => $this->get_mount_path(),
+			'started_at'       => $started_at,
+			'finished_at'      => $finished_at,
+			'duration_seconds' => $duration,
+			'status'           => $status,
+			'plugin_version'   => defined( 'SIMPLY_STATIC_VERSION' ) ? SIMPLY_STATIC_VERSION : null,
+			'studio_version'   => defined( 'SSS_VERSION' ) ? SSS_VERSION : null,
+			'wp_version'       => get_bloginfo( 'version' ),
+			'php_version'      => PHP_VERSION,
+			'theme'            => $this->get_theme(),
+			'detected_builders'=> $this->get_detected_builders(),
+			'export_config_hash' => $this->get_export_config_hash(),
+			'generate_type'    => $this->options->get( 'generate_type' ),
+			'url_counts'       => $counts,
+			'warnings'         => $warnings,
+			'errors'           => $errors,
+			'root_files'       => $this->summarize_root_files( $root_files ),
+			'snapshot_id'      => null,
+			'urls'             => $records,
+		);
+
+		return apply_filters( 'ss_deploy_manifest', $manifest, $records, $this );
+	}
+
+	/**
+	 * Return manifests for REST lists.
+	 *
+	 * @param int $page Current page.
+	 * @param int $per_page Per-page count.
+	 *
+	 * @return array
+	 */
+	public function get_exports( $page = 1, $per_page = 20 ) {
+		global $wpdb;
+
+		$page     = max( 1, (int) $page );
+		$per_page = max( 1, min( 100, (int) $per_page ) );
+		$offset   = ( $page - 1 ) * $per_page;
+		$table    = Deploy_Manifest::table_name();
+		$site_id  = (int) get_current_blog_id();
+		$total    = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM `{$table}` WHERE site_id = %d", $site_id ) );
+		$rows     = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT deploy_id, manifest_version, status, domain, mount_path, started_at, finished_at, duration_seconds, plugin_version, wp_version, php_version, generate_type, url_counts, root_files, warnings, errors FROM `{$table}` WHERE site_id = %d ORDER BY finished_at DESC, id DESC LIMIT %d OFFSET %d",
+				$site_id,
+				$per_page,
+				$offset
+			),
+			ARRAY_A
+		);
+
+		return array(
+			'exports'     => array_map( array( $this, 'format_manifest_summary_row' ), $rows ?: array() ),
+			'total'       => $total,
+			'total_pages' => (int) ceil( $total / $per_page ),
+			'page'        => $page,
+			'per_page'    => $per_page,
+		);
+	}
+
+	/**
+	 * Return latest stored manifest.
+	 *
+	 * @return array|null
+	 */
+	public function get_latest_manifest() {
+		global $wpdb;
+
+		$table   = Deploy_Manifest::table_name();
+		$site_id = (int) get_current_blog_id();
+		$row     = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM `{$table}` WHERE site_id = %d ORDER BY finished_at DESC, id DESC LIMIT 1",
+				$site_id
+			),
+			ARRAY_A
+		);
+
+		if ( empty( $row ) ) {
+			return null;
+		}
+
+		return $this->hydrate_manifest_row( $row );
+	}
+
+	/**
+	 * Return stored manifest by deploy ID.
+	 *
+	 * @param string $deploy_id Deploy ID.
+	 *
+	 * @return array|null
+	 */
+	public function get_manifest( $deploy_id ) {
+		global $wpdb;
+
+		$table   = Deploy_Manifest::table_name();
+		$site_id = (int) get_current_blog_id();
+		$row     = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM `{$table}` WHERE site_id = %d AND deploy_id = %s LIMIT 1",
+				$site_id,
+				$deploy_id
+			),
+			ARRAY_A
+		);
+
+		if ( empty( $row ) ) {
+			return null;
+		}
+
+		return $this->hydrate_manifest_row( $row );
+	}
+
+	/**
+	 * Return paginated URL records for a deploy.
+	 *
+	 * @param string $deploy_id Deploy ID.
+	 * @param array  $args Query args.
+	 *
+	 * @return array
+	 */
+	public function get_manifest_urls( $deploy_id, $args = array() ) {
+		global $wpdb;
+
+		$page     = max( 1, (int) ( $args['page'] ?? 1 ) );
+		$per_page = max( 1, min( 500, (int) ( $args['per_page'] ?? 100 ) ) );
+		$offset   = ( $page - 1 ) * $per_page;
+		$table    = Deploy_Manifest_Url::table_name();
+		$site_id  = (int) get_current_blog_id();
+		$where      = array( 'site_id = %d', 'deploy_id = %s' );
+		$where_args = array( $site_id, $deploy_id );
+
+		if ( ! empty( $args['status'] ) ) {
+			$status = sanitize_text_field( $args['status'] );
+			if ( is_numeric( $status ) ) {
+				$where[] = 'status_code = %d';
+				$where_args[] = (int) $status;
+			} elseif ( 'warning' === $status ) {
+				$where[] = "(warnings IS NOT NULL AND warnings != '' AND warnings != '[]')";
+			} elseif ( 'failed' === $status ) {
+				$where[] = "(errors IS NOT NULL AND errors != '' AND errors != '[]')";
+			}
+		}
+
+		if ( ! empty( $args['type'] ) ) {
+			$where[] = 'type = %s';
+			$where_args[] = sanitize_text_field( $args['type'] );
+		}
+
+		if ( ! empty( $args['search'] ) ) {
+			$like    = '%' . $wpdb->esc_like( sanitize_text_field( $args['search'] ) ) . '%';
+			$where[] = '(url LIKE %s OR static_path LIKE %s)';
+			$where_args[] = $like;
+			$where_args[] = $like;
+		}
+
+		$where_sql = 'WHERE ' . implode( ' AND ', $where );
+		$total     = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM `{$table}` {$where_sql}", $where_args ) );
+		$rows      = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM `{$table}` {$where_sql} ORDER BY status_code DESC, id ASC LIMIT %d OFFSET %d",
+				array_merge( $where_args, array( $per_page, $offset ) )
+			),
+			ARRAY_A
+		);
+
+		return array(
+			'urls'        => array_map( array( $this, 'format_url_row' ), $rows ?: array() ),
+			'total'       => $total,
+			'total_pages' => (int) ceil( $total / $per_page ),
+			'page'        => $page,
+			'per_page'    => $per_page,
+		);
+	}
+
+	/**
+	 * Return root/static file records for a deploy.
+	 *
+	 * @param string $deploy_id Deploy ID.
+	 *
+	 * @return array
+	 */
+	public function get_manifest_files( $deploy_id ) {
+		global $wpdb;
+
+		$table   = Deploy_Manifest_Url::table_name();
+		$site_id = (int) get_current_blog_id();
+		$types   = array( 'root_file', 'sitemap', 'markdown', 'file_override' );
+		$placeholders = implode( ',', array_fill( 0, count( $types ), '%s' ) );
+		$query_args   = array_merge( array( $site_id, $deploy_id ), $types );
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM `{$table}` WHERE site_id = %d AND deploy_id = %s AND type IN ({$placeholders}) ORDER BY status_code DESC, id ASC",
+				$query_args
+			),
+			ARRAY_A
+		);
+		$files = array_map( array( $this, 'format_url_row' ), $rows ?: array() );
+
+		return array(
+			'files' => $files,
+			'total' => count( $files ),
+		);
+	}
+
+	/**
+	 * Return warnings for a deploy.
+	 *
+	 * @param string $deploy_id Deploy ID.
+	 *
+	 * @return array
+	 */
+	public function get_manifest_warnings( $deploy_id ) {
+		$manifest = $this->get_manifest( $deploy_id );
+
+		if ( empty( $manifest ) ) {
+			return array( 'warnings' => array(), 'errors' => array() );
+		}
+
+		return array(
+			'warnings' => $manifest['warnings'],
+			'errors'   => $manifest['errors'],
+		);
+	}
+
+	/**
+	 * Persist manifest metadata and URL records.
+	 *
+	 * @param array $manifest Manifest.
+	 *
+	 * @return void
+	 */
+	protected function persist_manifest( $manifest ) {
+		global $wpdb;
+
+		$manifest_table = Deploy_Manifest::table_name();
+		$url_table      = Deploy_Manifest_Url::table_name();
+		$deploy_id      = $manifest['deploy_id'];
+		$site_id        = (int) get_current_blog_id();
+		$manifest_copy  = $manifest;
+		$urls           = $manifest_copy['urls'];
+		unset( $manifest_copy['urls'] );
+
+		$wpdb->delete( $manifest_table, array( 'deploy_id' => $deploy_id, 'site_id' => $site_id ) );
+		$wpdb->delete( $url_table, array( 'deploy_id' => $deploy_id, 'site_id' => $site_id ) );
+
+		$wpdb->insert(
+			$manifest_table,
+			array(
+				'deploy_id'        => $deploy_id,
+				'site_id'          => $site_id,
+				'manifest_version' => $manifest['manifest_version'],
+				'status'           => $manifest['status'],
+				'domain'           => $manifest['domain'],
+				'mount_path'       => $manifest['mount_path'],
+				'started_at'       => $manifest['started_at'],
+				'finished_at'      => $manifest['finished_at'],
+				'duration_seconds' => $manifest['duration_seconds'],
+				'plugin_version'   => $manifest['plugin_version'],
+				'wp_version'       => $manifest['wp_version'],
+				'php_version'      => $manifest['php_version'],
+				'generate_type'    => $manifest['generate_type'],
+				'url_counts'       => wp_json_encode( $manifest['url_counts'] ),
+				'root_files'       => wp_json_encode( $manifest['root_files'] ),
+				'warnings'         => wp_json_encode( $manifest['warnings'] ),
+				'errors'           => wp_json_encode( $manifest['errors'] ),
+				'manifest'         => wp_json_encode( $manifest_copy ),
+				'created_at'       => Util::formatted_datetime(),
+				'updated_at'       => Util::formatted_datetime(),
+			)
+		);
+
+		foreach ( $urls as $record ) {
+			$wpdb->insert(
+				$url_table,
+				array(
+					'deploy_id'          => $deploy_id,
+					'site_id'            => $site_id,
+					'url'                => $record['url'],
+					'source_url'         => $record['source_url'],
+					'static_path'        => $record['static_path'],
+					'type'               => $record['type'],
+					'status_code'        => $record['status_code'],
+					'content_hash'       => $record['content_hash'],
+					'file_size'          => $record['file_size'],
+					'redirect_target'    => $record['redirect_target'],
+					'found_on'           => wp_json_encode( $record['found_on'] ),
+					'in_sitemap'         => $this->nullable_bool_to_db( $record['in_sitemap'] ),
+					'markdown_generated' => $this->nullable_bool_to_db( $record['markdown_generated'] ),
+					'warnings'           => wp_json_encode( $record['warnings'] ),
+					'errors'             => wp_json_encode( $record['errors'] ),
+					'created_at'         => Util::formatted_datetime(),
+					'updated_at'         => Util::formatted_datetime(),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Build URL records from Page rows.
+	 *
+	 * @return array
+	 */
+	protected function build_url_records() {
+		$query = Page::query()->order( 'url ASC' );
+		$scope = $this->get_export_scope();
+		$this->apply_scope( $query, $scope );
+		$pages = $query->find();
+
+		if ( empty( $pages ) ) {
+			return array();
+		}
+
+		$records = array();
+
+		foreach ( $pages as $page ) {
+			$records[] = $this->format_page_record( $page );
+		}
+
+		return $records;
+	}
+
+	/**
+	 * Format a Page model as a manifest URL record.
+	 *
+	 * @param Page $page Page model.
+	 *
+	 * @return array
+	 */
+	protected function format_page_record( $page ) {
+		$found_on = array();
+		$parent   = $page->parent_static_page();
+
+		if ( $parent ) {
+			$found_on[] = $parent->url;
+		}
+
+		$warnings = $this->parse_messages( $page->status_message );
+		$errors   = $this->parse_messages( $page->error_message );
+		$type     = $this->detect_record_type( $page );
+
+		return array(
+			'url'                => $page->url,
+			'source_url'         => null,
+			'static_path'        => $page->file_path,
+			'type'               => $type,
+			'status_code'        => null === $page->http_status_code ? null : (int) $page->http_status_code,
+			'content_hash'       => $this->format_content_hash( $page->content_hash ),
+			'file_size'          => $this->get_file_size( $page->file_path ),
+			'redirect_target'    => $page->redirect_url,
+			'found_on'           => $found_on,
+			'in_sitemap'         => null,
+			'markdown_generated' => 'markdown' === $type ? true : null,
+			'warnings'           => $warnings,
+			'errors'             => $errors,
+		);
+	}
+
+	/**
+	 * Detect manifest type for a page row.
+	 *
+	 * @param Page $page Page model.
+	 *
+	 * @return string
+	 */
+	protected function detect_record_type( $page ) {
+		$path = ltrim( (string) $page->file_path, '/' );
+		$url_path = trim( (string) wp_parse_url( $page->url, PHP_URL_PATH ), '/' );
+		$status = (int) $page->http_status_code;
+
+		if ( in_array( $status, array( 301, 302, 303, 307, 308 ), true ) || ! empty( $page->redirect_url ) ) {
+			return 'redirect';
+		}
+
+		if ( preg_match( '/\.md$/i', $path ) || preg_match( '/\.md$/i', $url_path ) ) {
+			return 'markdown';
+		}
+
+		if ( $this->is_sitemap_path( $path ) || $this->is_sitemap_path( $url_path ) ) {
+			return 'sitemap';
+		}
+
+		if ( $this->is_root_path( $path ) || $this->is_root_path( $url_path ) ) {
+			return 'root_file';
+		}
+
+		if ( $page->is_type( 'text/html' ) || '' === $path || preg_match( '#(^|/)index\.html?$#i', $path ) ) {
+			return 'page';
+		}
+
+		if ( $page->is_binary_file() || preg_match( '/\.(css|js|png|jpe?g|gif|webp|svg|ico|avif|pdf|woff2?|ttf|eot|mp4|webm|mp3|wav)$/i', $path ) ) {
+			return 'asset';
+		}
+
+		if ( false !== strpos( $url_path, 'wp-json/' ) ) {
+			return 'api';
+		}
+
+		return 'other';
+	}
+
+	/**
+	 * Count URL records by status/type.
+	 *
+	 * @param array $records URL records.
+	 *
+	 * @return array
+	 */
+	protected function count_url_records( $records ) {
+		$counts = array(
+			'total'          => count( $records ),
+			'successful'     => 0,
+			'redirects'      => 0,
+			'not_found'      => 0,
+			'failed'         => 0,
+			'skipped'        => 0,
+			'assets'         => 0,
+			'root_files'     => 0,
+			'markdown_files' => 0,
+			'warnings'       => 0,
+			'errors'         => 0,
+		);
+
+		foreach ( $records as $record ) {
+			$status = (int) $record['status_code'];
+
+			if ( $status >= 200 && $status < 300 ) {
+				$counts['successful']++;
+			} elseif ( $status >= 300 && $status < 400 ) {
+				$counts['redirects']++;
+			} elseif ( 404 === $status ) {
+				$counts['not_found']++;
+			} elseif ( $status >= 400 || ! empty( $record['errors'] ) ) {
+				$counts['failed']++;
+			}
+
+			if ( 'asset' === $record['type'] ) {
+				$counts['assets']++;
+			}
+
+			if ( in_array( $record['type'], array( 'root_file', 'sitemap' ), true ) ) {
+				$counts['root_files']++;
+			}
+
+			if ( 'markdown' === $record['type'] ) {
+				$counts['markdown_files']++;
+			}
+
+			if ( ! empty( $record['warnings'] ) ) {
+				$counts['warnings']++;
+			}
+
+			if ( ! empty( $record['errors'] ) ) {
+				$counts['errors']++;
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Get current export scope.
+	 *
+	 * @return array
+	 */
+	protected function get_export_scope() {
+		$use_single         = get_option( 'simply-static-use-single' );
+		$use_build          = get_option( 'simply-static-use-build' );
+		$generate_type      = $this->options->get( 'generate_type' );
+		$archive_start_time = $this->options->get( 'archive_start_time' );
+
+		if ( ! empty( $use_single ) ) {
+			$ids = array_values( array_filter( array_map( 'intval', explode( ',', $use_single ) ) ) );
+
+			if ( ! empty( $ids ) ) {
+				return array(
+					'type' => 'single',
+					'ids'  => $ids,
+				);
+			}
+		}
+
+		if ( 'update' === $generate_type && empty( $use_build ) && ! empty( $archive_start_time ) ) {
+			return array(
+				'type'               => 'update',
+				'archive_start_time' => $archive_start_time,
+			);
+		}
+
+		return array();
+	}
+
+	/**
+	 * Apply export scope to a query.
+	 *
+	 * @param Query $query Query object.
+	 * @param array $scope Scope.
+	 *
+	 * @return void
+	 */
+	protected function apply_scope( $query, $scope ) {
+		if ( empty( $scope ) || empty( $scope['type'] ) ) {
+			return;
+		}
+
+		if ( 'single' === $scope['type'] && ! empty( $scope['ids'] ) ) {
+			$ids = array_map( 'intval', $scope['ids'] );
+
+			if ( count( $ids ) === 1 ) {
+				$query->where( 'post_id = ?', $ids[0] );
+			} else {
+				$query->where( 'post_id IN (' . implode( ',', $ids ) . ')' );
+			}
+		}
+
+		if ( 'update' === $scope['type'] && ! empty( $scope['archive_start_time'] ) ) {
+			$query->where( 'last_checked_at >= ?', $scope['archive_start_time'] );
+			$query->where( 'updated_at >= ?', $scope['archive_start_time'] );
+		}
+	}
+
+	/**
+	 * Create a deploy id.
+	 *
+	 * @return string
+	 */
+	protected function new_deploy_id() {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return wp_generate_uuid4();
+		}
+
+		return uniqid( 'deploy_', true );
+	}
+
+	/**
+	 * Normalize export status.
+	 *
+	 * @param string $result Result.
+	 *
+	 * @return string
+	 */
+	protected function normalize_status( $result ) {
+		if ( 'success' === $result ) {
+			return 'success';
+		}
+
+		if ( 'cancel' === $result || 'cancelled' === $result ) {
+			return 'cancelled';
+		}
+
+		return 'failed';
+	}
+
+	/**
+	 * Parse semicolon-separated messages.
+	 *
+	 * @param string|null $messages Messages.
+	 *
+	 * @return array
+	 */
+	protected function parse_messages( $messages ) {
+		if ( empty( $messages ) ) {
+			return array();
+		}
+
+		$parts = array_filter( array_map( 'trim', explode( ';', wp_strip_all_tags( (string) $messages ) ) ) );
+
+		return array_values(
+			array_map(
+				function ( $message ) {
+					return array(
+						'code'    => sanitize_key( substr( $message, 0, 40 ) ),
+						'message' => $message,
+					);
+				},
+				array_unique( $parts )
+			)
+		);
+	}
+
+	/**
+	 * Collect global messages from URL records.
+	 *
+	 * @param array  $records URL records.
+	 * @param string $key warnings or errors.
+	 *
+	 * @return array
+	 */
+	protected function collect_manifest_messages( $records, $key ) {
+		$messages = array();
+
+		foreach ( $records as $record ) {
+			if ( empty( $record[ $key ] ) ) {
+				continue;
+			}
+
+			foreach ( $record[ $key ] as $message ) {
+				$message['url'] = $record['url'];
+				$messages[] = $message;
+			}
+		}
+
+		return $messages;
+	}
+
+	/**
+	 * Is a root/static file record.
+	 *
+	 * @param array $record URL record.
+	 *
+	 * @return bool
+	 */
+	protected function is_root_record( $record ) {
+		return in_array( $record['type'], array( 'root_file', 'sitemap' ), true );
+	}
+
+	/**
+	 * Summarize root files.
+	 *
+	 * @param array $records Root records.
+	 *
+	 * @return array
+	 */
+	protected function summarize_root_files( $records ) {
+		return array_map(
+			function ( $record ) {
+				return array(
+					'url'          => $record['url'],
+					'static_path'  => $record['static_path'],
+					'type'         => $record['type'],
+					'status_code'  => $record['status_code'],
+					'content_hash' => $record['content_hash'],
+					'file_size'    => $record['file_size'],
+					'warnings'     => $record['warnings'],
+					'errors'       => $record['errors'],
+				);
+			},
+			$records
+		);
+	}
+
+	/**
+	 * Is sitemap path.
+	 *
+	 * @param string $path Path.
+	 *
+	 * @return bool
+	 */
+	protected function is_sitemap_path( $path ) {
+		return (bool) preg_match( '#(^|/)sitemap[^/]*\.xml$#i', (string) $path );
+	}
+
+	/**
+	 * Is supported root file path.
+	 *
+	 * @param string $path Path.
+	 *
+	 * @return bool
+	 */
+	protected function is_root_path( $path ) {
+		$path = ltrim( (string) $path, '/' );
+
+		return (bool) preg_match( '#^(robots|llms|ads|security|humans)\.txt$#i', $path )
+			|| (bool) preg_match( '#^\.well-known/#i', $path );
+	}
+
+	/**
+	 * Get final file size if available.
+	 *
+	 * @param string|null $file_path Static path.
+	 *
+	 * @return int|null
+	 */
+	protected function get_file_size( $file_path ) {
+		if ( empty( $file_path ) ) {
+			return null;
+		}
+
+		$archive_dir = $this->options->get_archive_dir();
+		$full_path   = trailingslashit( $archive_dir ) . ltrim( $file_path, '/\\' );
+
+		return file_exists( $full_path ) ? filesize( $full_path ) : null;
+	}
+
+	/**
+	 * Normalize content hash.
+	 *
+	 * @param string|null $hash Hash.
+	 *
+	 * @return string|null
+	 */
+	protected function format_content_hash( $hash ) {
+		if ( empty( $hash ) ) {
+			return null;
+		}
+
+		if ( preg_match( '/^[a-f0-9]{40,64}$/i', $hash ) ) {
+			return 'sha1:' . strtolower( $hash );
+		}
+
+		return 'sha1:' . bin2hex( $hash );
+	}
+
+	/**
+	 * Get public domain.
+	 *
+	 * @return string
+	 */
+	protected function get_domain() {
+		$destination = $this->options->get_destination_url();
+
+		if ( empty( $destination ) || './' === $destination ) {
+			$destination = home_url();
+		}
+
+		return untrailingslashit( $destination );
+	}
+
+	/**
+	 * Get mount path when Studio stores it in options.
+	 *
+	 * @return string
+	 */
+	protected function get_mount_path() {
+		$mount_path = $this->options->get( 'sss_mount_path' );
+
+		if ( empty( $mount_path ) ) {
+			$mount_path = $this->options->get( 'cdn_directory' );
+		}
+
+		$mount_path = trim( (string) $mount_path );
+		if ( '' === $mount_path || '/' === $mount_path ) {
+			return '';
+		}
+
+		return '/' . trim( $mount_path, '/' );
+	}
+
+	/**
+	 * Get active theme metadata.
+	 *
+	 * @return array
+	 */
+	protected function get_theme() {
+		$theme = wp_get_theme();
+
+		return array(
+			'name'    => $theme->get( 'Name' ),
+			'version' => $theme->get( 'Version' ),
+		);
+	}
+
+	/**
+	 * Detect common builders from active plugins.
+	 *
+	 * @return array
+	 */
+	protected function get_detected_builders() {
+		$builders = array();
+
+		if ( defined( 'ELEMENTOR_VERSION' ) ) {
+			$builders[] = 'Elementor';
+		}
+
+		if ( class_exists( 'FLBuilder' ) ) {
+			$builders[] = 'Beaver Builder';
+		}
+
+		if ( defined( 'ET_BUILDER_PLUGIN_VERSION' ) || function_exists( 'et_setup_theme' ) ) {
+			$builders[] = 'Divi';
+		}
+
+		if ( defined( 'BRICKS_VERSION' ) ) {
+			$builders[] = 'Bricks';
+		}
+
+		if ( defined( 'CT_VERSION' ) || defined( 'OXYGEN_VERSION' ) ) {
+			$builders[] = 'Oxygen';
+		}
+
+		return array_values( array_unique( apply_filters( 'ss_deploy_manifest_detected_builders', $builders ) ) );
+	}
+
+	/**
+	 * Hash export settings relevant to the manifest.
+	 *
+	 * @return string
+	 */
+	protected function get_export_config_hash() {
+		$options = $this->options->get_as_array();
+		$keys    = array(
+			'destination_url_type',
+			'destination_scheme',
+			'destination_host',
+			'relative_path',
+			'delivery_method',
+			'cdn_directory',
+			'sss_mount_path',
+			'generate_type',
+			'additional_urls',
+			'additional_files',
+			'urls_to_exclude',
+			'smart_crawl',
+		);
+		$config = array();
+
+		foreach ( $keys as $key ) {
+			if ( array_key_exists( $key, $options ) ) {
+				$config[ $key ] = $options[ $key ];
+			}
+		}
+
+		return 'sha256:' . hash( 'sha256', wp_json_encode( $config ) );
+	}
+
+	/**
+	 * Format a stored manifest row.
+	 *
+	 * @param array $row Row.
+	 *
+	 * @return array
+	 */
+	protected function hydrate_manifest_row( $row ) {
+		$manifest = json_decode( $row['manifest'], true );
+		if ( ! is_array( $manifest ) ) {
+			$manifest = array();
+		}
+
+		$manifest['urls'] = $this->get_manifest_urls(
+			$row['deploy_id'],
+			array(
+				'page'     => 1,
+				'per_page' => 200,
+			)
+		);
+
+		return $manifest;
+	}
+
+	/**
+	 * Format a summary row.
+	 *
+	 * @param array $row Row.
+	 *
+	 * @return array
+	 */
+	protected function format_manifest_summary_row( $row ) {
+		$row['url_counts'] = $this->decode_json_field( $row['url_counts'] );
+		$row['root_files'] = $this->decode_json_field( $row['root_files'] );
+		$row['warnings']   = $this->decode_json_field( $row['warnings'] );
+		$row['errors']     = $this->decode_json_field( $row['errors'] );
+
+		return $row;
+	}
+
+	/**
+	 * Format a URL row.
+	 *
+	 * @param array $row Row.
+	 *
+	 * @return array
+	 */
+	protected function format_url_row( $row ) {
+		$row['status_code']        = null === $row['status_code'] ? null : (int) $row['status_code'];
+		$row['file_size']          = null === $row['file_size'] ? null : (int) $row['file_size'];
+		$row['found_on']           = $this->decode_json_field( $row['found_on'] );
+		$row['in_sitemap']         = $this->db_to_nullable_bool( $row['in_sitemap'] );
+		$row['markdown_generated'] = $this->db_to_nullable_bool( $row['markdown_generated'] );
+		$row['warnings']           = $this->decode_json_field( $row['warnings'] );
+		$row['errors']             = $this->decode_json_field( $row['errors'] );
+
+		unset( $row['id'], $row['site_id'], $row['created_at'], $row['updated_at'] );
+
+		return $row;
+	}
+
+	/**
+	 * Decode JSON field.
+	 *
+	 * @param string|null $value JSON value.
+	 *
+	 * @return array
+	 */
+	protected function decode_json_field( $value ) {
+		if ( empty( $value ) ) {
+			return array();
+		}
+
+		$decoded = json_decode( $value, true );
+
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
+	 * Convert nullable bool to DB value.
+	 *
+	 * @param bool|null $value Value.
+	 *
+	 * @return int|null
+	 */
+	protected function nullable_bool_to_db( $value ) {
+		if ( null === $value ) {
+			return null;
+		}
+
+		return $value ? 1 : 0;
+	}
+
+	/**
+	 * Convert DB value to nullable bool.
+	 *
+	 * @param mixed $value Value.
+	 *
+	 * @return bool|null
+	 */
+	protected function db_to_nullable_bool( $value ) {
+		if ( null === $value ) {
+			return null;
+		}
+
+		return (bool) $value;
+	}
+}

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -132,6 +132,7 @@ class Plugin {
 				Admin_Settings::get_instance();
 				// Register admin REST routes in a dedicated controller.
 				Admin_Rest::get_instance();
+				Deploy_Manifest_Service::get_instance();
 
 				// Dashboard widget.
 				Admin_Dashboard_Widget::get_instance();
@@ -189,6 +190,9 @@ class Plugin {
 		require_once $path . 'src/class-ss-query.php';
 		require_once $path . 'src/models/class-ss-model.php';
 		require_once $path . 'src/models/class-ss-page.php';
+		require_once $path . 'src/models/class-ss-deploy-manifest.php';
+		require_once $path . 'src/models/class-ss-deploy-manifest-url.php';
+		require_once $path . 'src/class-ss-deploy-manifest-service.php';
 		require_once $path . 'src/class-ss-diagnostic.php';
 		require_once $path . 'src/class-ss-sql-permissions.php';
 		require_once $path . 'src/class-ss-upgrade-handler.php';

--- a/src/class-ss-upgrade-handler.php
+++ b/src/class-ss-upgrade-handler.php
@@ -189,6 +189,8 @@ class Upgrade_Handler {
 			'sftp_port'                     => 22,
 			'sftp_bulk_upload'              => false,
 			'archive_status_messages'       => array(),
+			'archive_deploy_id'             => null,
+			'deploy_manifest_schema_version'=> null,
 			'pages_status'                  => array(),
 			'archive_name'                  => null,
 			'archive_start_time'            => null,
@@ -197,15 +199,18 @@ class Upgrade_Handler {
 		);
 
 		$version = self::$options->get( 'version' );
+		self::maybe_update_manifest_schema();
 
 		// New installation, set default options.
 		if ( null === $version ) {
 			Page::create_or_update_table();
+			Deploy_Manifest_Service::create_or_update_tables();
 			self::set_default_options();
 		} else {
 			if ( version_compare( $version, SIMPLY_STATIC_VERSION, '!=' ) ) {
 				// Sync database.
 				Page::create_or_update_table();
+				Deploy_Manifest_Service::create_or_update_tables();
 
 				// Preserve legacy Hide WP path settings under the current option names.
 				self::migrate_legacy_hide_wp_options();
@@ -240,6 +245,23 @@ class Upgrade_Handler {
 
 		// Save the options
 		self::$options->save();
+	}
+
+	/**
+	 * Create or update deploy manifest tables when the schema version changes.
+	 *
+	 * @return void
+	 */
+	protected static function maybe_update_manifest_schema() {
+		if ( self::$options->get( 'deploy_manifest_schema_version' ) === Deploy_Manifest_Service::SCHEMA_VERSION ) {
+			return;
+		}
+
+		Deploy_Manifest_Service::create_or_update_tables();
+
+		self::$options
+			->set( 'deploy_manifest_schema_version', Deploy_Manifest_Service::SCHEMA_VERSION )
+			->save();
 	}
 
 	/**

--- a/src/models/class-ss-deploy-manifest-url.php
+++ b/src/models/class-ss-deploy-manifest-url.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Simply_Static;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stored URL/file records for a deploy manifest.
+ */
+class Deploy_Manifest_Url extends Model {
+
+	/**
+	 * Database table name.
+	 *
+	 * @var string
+	 */
+	protected static $table_name = 'deploy_manifest_urls';
+
+	/**
+	 * Table columns.
+	 *
+	 * @var array
+	 */
+	protected static $columns = array(
+		'id'                 => 'BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT',
+		'deploy_id'          => 'VARCHAR(80) NOT NULL',
+		'site_id'            => 'BIGINT(20) UNSIGNED NULL',
+		'url'                => 'TEXT NOT NULL',
+		'source_url'         => 'TEXT NULL',
+		'static_path'        => 'TEXT NULL',
+		'type'               => 'VARCHAR(30) NOT NULL',
+		'status_code'        => 'SMALLINT(20) NULL',
+		'content_hash'       => 'VARCHAR(96) NULL',
+		'file_size'          => 'BIGINT(20) NULL',
+		'redirect_target'    => 'TEXT NULL',
+		'found_on'           => 'LONGTEXT NULL',
+		'in_sitemap'         => 'TINYINT(1) NULL',
+		'markdown_generated' => 'TINYINT(1) NULL',
+		'warnings'           => 'LONGTEXT NULL',
+		'errors'             => 'LONGTEXT NULL',
+		'created_at'         => "DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'",
+		'updated_at'         => "DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'"
+	);
+
+	/**
+	 * Indexes for columns.
+	 *
+	 * @var array
+	 */
+	protected static $indexes = array(
+		'PRIMARY KEY  (id)',
+		'KEY deploy_id (deploy_id)',
+		'KEY site_id (site_id)',
+		'KEY type (type)',
+		'KEY status_code (status_code)'
+	);
+
+	/**
+	 * Primary key.
+	 *
+	 * @var string
+	 */
+	protected static $primary_key = 'id';
+}

--- a/src/models/class-ss-deploy-manifest.php
+++ b/src/models/class-ss-deploy-manifest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Simply_Static;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stored deploy manifest metadata.
+ */
+class Deploy_Manifest extends Model {
+
+	/**
+	 * Database table name.
+	 *
+	 * @var string
+	 */
+	protected static $table_name = 'deploy_manifests';
+
+	/**
+	 * Table columns.
+	 *
+	 * @var array
+	 */
+	protected static $columns = array(
+		'id'                => 'BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT',
+		'deploy_id'         => 'VARCHAR(80) NOT NULL',
+		'site_id'           => 'BIGINT(20) UNSIGNED NULL',
+		'manifest_version'  => 'VARCHAR(20) NOT NULL',
+		'status'            => 'VARCHAR(30) NOT NULL',
+		'domain'            => 'VARCHAR(255) NULL',
+		'mount_path'        => 'VARCHAR(255) NULL',
+		'started_at'        => "DATETIME NULL DEFAULT '0000-00-00 00:00:00'",
+		'finished_at'       => "DATETIME NULL DEFAULT '0000-00-00 00:00:00'",
+		'duration_seconds'  => 'INT(11) NULL',
+		'plugin_version'    => 'VARCHAR(30) NULL',
+		'wp_version'        => 'VARCHAR(30) NULL',
+		'php_version'       => 'VARCHAR(30) NULL',
+		'generate_type'     => 'VARCHAR(30) NULL',
+		'url_counts'        => 'LONGTEXT NULL',
+		'root_files'        => 'LONGTEXT NULL',
+		'warnings'          => 'LONGTEXT NULL',
+		'errors'            => 'LONGTEXT NULL',
+		'manifest'          => 'LONGTEXT NULL',
+		'created_at'        => "DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'",
+		'updated_at'        => "DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'"
+	);
+
+	/**
+	 * Indexes for columns.
+	 *
+	 * @var array
+	 */
+	protected static $indexes = array(
+		'PRIMARY KEY  (id)',
+		'UNIQUE KEY deploy_id (deploy_id)',
+		'KEY site_id (site_id)',
+		'KEY status (status)',
+		'KEY finished_at (finished_at)'
+	);
+
+	/**
+	 * Primary key.
+	 *
+	 * @var string
+	 */
+	protected static $primary_key = 'id';
+}


### PR DESCRIPTION
## Summary
- Adds deploy manifest tables, models, and a service that records export metadata plus URL/file records when exports complete.
- Adds admin REST endpoints for listing exports, fetching the latest or a specific export, and reading URL, file, and warning data.
- Tracks a deploy ID per archive run and captures end times for error and exception completions.

## Testing
- php -l on all changed PHP files
- git diff --check