### PR TITLE
Handle hosted WordPress resource hints

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -96,7 +96,7 @@ class Url_Extractor {
 		'wml'      => array( 'xmlns' ),
 
 		'meta' => array( 'content' ),
-		'link' => array( 'href', 'data-pmdelayedstyle' ),
+		'link' => array( 'href', 'imagesrcset', 'data-pmdelayedstyle' ),
 		'atom' => array( 'href' ),
 	);
 
@@ -888,7 +888,10 @@ class Url_Extractor {
 		// Remove local resource hints. They are useless in static output and can
 		// expose a hidden WordPress/staging host in proxy/custom-domain setups.
 		if ( 'link' === $tag_name && $tag->hasAttribute( 'rel' ) && $tag->hasAttribute( 'href' ) ) {
-			if ( $this->is_local_resource_hint( $tag->getAttribute( 'rel' ), $tag->getAttribute( 'href' ) ) ) {
+			$rel  = $tag->getAttribute( 'rel' );
+			$href = $tag->getAttribute( 'href' );
+
+			if ( $this->is_local_resource_hint( $rel, $href ) || $this->is_current_wordpress_resource_hint( $rel, $href ) ) {
 				$tag->parentNode->removeChild( $tag );
 
 				return;
@@ -1019,6 +1022,54 @@ class Url_Extractor {
 		}
 
 		return Util::is_local_url( $url );
+	}
+
+	/**
+	 * Determine if a resource hint points at a current WordPress host.
+	 *
+	 * The hint may be only scheme + host, so it cannot be detected as a local
+	 * asset URL by the normal path-based checks.
+	 *
+	 * @param string $rel  Link rel attribute.
+	 * @param string $href Link href attribute.
+	 *
+	 * @return bool
+	 */
+	private function is_current_wordpress_resource_hint( $rel, $href ) {
+		$rel_tokens = preg_split( '/\s+/', strtolower( trim( (string) $rel ) ) );
+		$rel_tokens = is_array( $rel_tokens ) ? array_filter( $rel_tokens ) : array();
+
+		if ( ! array_intersect( $rel_tokens, array( 'preconnect', 'dns-prefetch' ) ) ) {
+			return false;
+		}
+
+		$href = trim( (string) $href );
+		if ( '' === $href ) {
+			return false;
+		}
+
+		$url = Util::relative_to_absolute_url( $href, $this->static_page->url );
+		if ( ! is_string( $url ) || '' === $url ) {
+			return false;
+		}
+
+		if ( 0 === strpos( $url, '//' ) ) {
+			$url = Util::origin_scheme() . ':' . $url;
+		}
+
+		$url_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url );
+		$host      = is_array( $url_parts ) && ! empty( $url_parts['host'] ) ? strtolower( (string) $url_parts['host'] ) : '';
+
+		$is_current_wordpress_host = Util::is_current_wordpress_host( $host );
+
+		return (bool) apply_filters(
+			'ss_remove_current_wordpress_resource_hint',
+			$is_current_wordpress_host,
+			$url,
+			$rel,
+			$this->static_page,
+			$this
+		);
 	}
 
 	/**

--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -964,7 +964,82 @@ class Util {
 			return $scheme . '://' . $url_parts['host'] . $port;
 		}
 
+		if ( self::is_current_wordpress_host( $url_host ) && self::is_root_wordpress_asset_path( $url_path ) ) {
+			$scheme = isset( $url_parts['scheme'] ) ? $url_parts['scheme'] : self::origin_scheme();
+			$port   = isset( $url_parts['port'] ) ? ':' . $url_parts['port'] : '';
+
+			return $scheme . '://' . $url_parts['host'] . $port;
+		}
+
 		return null;
+	}
+
+	/**
+	 * Check whether a host is a WordPress origin for this export.
+	 *
+	 * @param string $host URL host.
+	 *
+	 * @return bool
+	 */
+	public static function is_current_wordpress_host( $host ) {
+		$host = self::normalize_url_host( $host );
+		if ( '' === $host ) {
+			return false;
+		}
+
+		$allowed_hosts             = self::current_wordpress_hosts();
+		$is_current_wordpress_host = in_array( $host, $allowed_hosts, true );
+
+		return (bool) apply_filters(
+			'ss_is_current_wordpress_host',
+			$is_current_wordpress_host,
+			$host,
+			$allowed_hosts
+		);
+	}
+
+	/**
+	 * Get WordPress hosts that should be treated as local.
+	 *
+	 * @return array
+	 */
+	private static function current_wordpress_hosts() {
+		$hosts = array();
+
+		foreach ( self::local_url_bases() as $base ) {
+			$base_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $base ) : parse_url( $base );
+			if ( is_array( $base_parts ) && ! empty( $base_parts['host'] ) ) {
+				$hosts[] = $base_parts['host'];
+			}
+		}
+
+		if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
+			$hosts[] = function_exists( 'wp_unslash' ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : $_SERVER['HTTP_HOST'];
+		}
+
+		if ( ! empty( $_SERVER['SERVER_NAME'] ) ) {
+			$hosts[] = function_exists( 'wp_unslash' ) ? wp_unslash( $_SERVER['SERVER_NAME'] ) : $_SERVER['SERVER_NAME'];
+		}
+
+		$hosts = (array) apply_filters( 'ss_current_wordpress_hosts', $hosts );
+		$hosts = array_map( array( __CLASS__, 'normalize_url_host' ), $hosts );
+		$hosts = array_filter( $hosts );
+		$hosts = array_values( array_unique( $hosts ) );
+
+		return $hosts;
+	}
+
+	/**
+	 * Normalize a URL host value for comparison.
+	 *
+	 * @param string $host URL host.
+	 *
+	 * @return string
+	 */
+	private static function normalize_url_host( $host ) {
+		$host = strtolower( trim( (string) $host, ". \t\n\r\0\x0B" ) );
+
+		return preg_replace( '/:\d+$/', '', $host );
 	}
 
 	/**


### PR DESCRIPTION
Treat root WordPress asset URLs from the current WordPress host as local so hosted/proxy origins are rewritten during export. Remove dns-prefetch and preconnect hints that point back to the current WordPress host to avoid leaking private or staging origins in static output. Also process link imagesrcset attributes so responsive image preloads are rewritten consistently.