### PR TITLE
Bump version to 3.7.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jamstack, performance, security, static site generator
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag:  3.7.8
+Stable tag:  3.7.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -274,6 +274,14 @@ Settings - Configure your static site export options
 Diagnostics - Check your WordPress environment for compatibility
 
 == Changelog ==
+
+= 3.7.9 =
+
+* Added Beaver Builder cache integration
+* Improved resource hint handling for hosted WordPress and local exports
+* Fixed Gutenberg background URL placeholder extraction
+* Updated Static Studio promo copy
+* Updated NPM dependencies
 
 = 3.7.8 =
 

--- a/simply-static.php
+++ b/simply-static.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Simply Static
  * Plugin URI:        https://simplystatic.com
  * Description:       A static site generator to create fast and secure static versions of your WordPress website.
- * Version:           3.7.8
+ * Version:           3.7.9
  * Author:            Patrick Posner
  * Author URI:        https://patrickposner.com
  * License:           GPL-2.0+
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'SIMPLY_STATIC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLY_STATIC_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'SIMPLY_STATIC_VERSION', '3.7.8' );
+define( 'SIMPLY_STATIC_VERSION', '3.7.9' );
 
 // Check PHP version.
 if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {


### PR DESCRIPTION
Bumps the Simply Static plugin version and stable tag from 3.7.8 to 3.7.9. Adds the 3.7.9 changelog entry covering the release highlights: Beaver Builder cache integration, resource hint handling improvements, Gutenberg background URL extraction, Studio promo copy updates, and NPM dependency updates.