### PR TITLE
Exclude private backup uploads from exports

### DIFF
--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -811,6 +811,15 @@ class Util {
 			return false;
 		}
 
+		// Backup archives and their metadata are private working files. Keep this
+		// check in the central exclusion path so previously queued records are also
+		// skipped on later exports, not only during uploads-directory discovery.
+		if ( self::is_private_backup_path( $url ) ) {
+			self::debug_log( sprintf( 'Excluding URL "%s" — matched built-in rule: Simply Static private backup directory', $url ) );
+
+			return true;
+		}
+
 		$excluded = array( '.php' );
 		$opts     = Options::instance();
 
@@ -924,6 +933,31 @@ class Util {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Determine whether a URL or relative path points into a private Simply
+	 * Static backup directory.
+	 *
+	 * Backup/Migrate stores working files below
+	 * uploads/simply-static/backup-{32-character random key}/. These files may
+	 * contain archives and installation metadata and must never become static
+	 * site artifacts.
+	 *
+	 * @param string $path URL or filesystem-style relative path.
+	 *
+	 * @return bool
+	 */
+	public static function is_private_backup_path( string $path ): bool {
+		$url_path = function_exists( 'wp_parse_url' ) ? wp_parse_url( $path, PHP_URL_PATH ) : parse_url( $path, PHP_URL_PATH );
+
+		if ( is_string( $url_path ) && '' !== $url_path ) {
+			$path = $url_path;
+		}
+
+		$path = self::normalize_slashes( rawurldecode( $path ) );
+
+		return 1 === preg_match( '#(?:^|/)simply-static/backup-[a-f0-9]{32}(?:/|$)#i', $path );
 	}
 
 	/**

--- a/src/crawler/class-ss-uploads-crawler.php
+++ b/src/crawler/class-ss-uploads-crawler.php
@@ -191,6 +191,9 @@ class Uploads_Crawler extends Crawler {
 					}
 
 					$relative_path = \Simply_Static\Util::safe_relative_path( $base_dir, $file->getPathname() );
+					if ( \Simply_Static\Util::is_private_backup_path( $relative_path ) ) {
+						continue;
+					}
 
 					// Skip files in ignored directories
 					$skip = false;
@@ -390,7 +393,11 @@ class Uploads_Crawler extends Crawler {
 		foreach ( $files as $file ) {
 			// Build a safe relative path and evaluate skip rules
 			$relative_path = \Simply_Static\Util::safe_relative_path( $dir, $file->getPathname() );
-			$should_skip   = false;
+			if ( \Simply_Static\Util::is_private_backup_path( $relative_path ) ) {
+				continue;
+			}
+
+			$should_skip = false;
 
 			foreach ( $skip_dirs as $skip_dir ) {
 				if ( strpos( $relative_path, '/' . $skip_dir . '/' ) !== false ) {

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -62,6 +62,12 @@ class Fetch_Urls_Task extends Task {
 		// page, then we don't need to bother fetching it.
 		if ( $save_file === false && $follow_urls === false ) {
 			Util::debug_log( "Skipping URL because it is no-save and no-follow" );
+			// Incremental exports retain page records. Clear an older generated path
+			// so a backup that was queued before this built-in exclusion cannot be
+			// picked up by a later deployment task.
+			if ( Util::is_private_backup_path( $static_page->url ) ) {
+				$static_page->file_path = null;
+			}
 			$static_page->last_checked_at = Util::formatted_datetime();
 			$static_page->set_status_message( __( "Do not save or follow", 'simply-static' ) );
 			$static_page->save();

--- a/tests/Support/wordpress-stubs.php
+++ b/tests/Support/wordpress-stubs.php
@@ -202,6 +202,14 @@ function site_url( $path = '' ) {
 	return rtrim( WpEnv::$site_url, '/' ) . ( '' === $path ? '' : '/' . ltrim( (string) $path, '/' ) );
 }
 
+function includes_url( $path = '' ) {
+	return rtrim( WpEnv::$site_url, '/' ) . '/wp-includes/' . ltrim( (string) $path, '/' );
+}
+
+function plugins_url( $path = '', $plugin = '' ) {
+	return rtrim( WP_PLUGIN_URL, '/' ) . '/' . ltrim( (string) $path, '/' );
+}
+
 function admin_url( $path = '' ) {
 	return site_url( 'wp-admin/' . ltrim( (string) $path, '/' ) );
 }

--- a/tests/Unit/FetchUrlsExclusionTest.php
+++ b/tests/Unit/FetchUrlsExclusionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use ReflectionMethod;
+use Simply_Static\Fetch_Urls_Task;
+use Simply_Static\Options;
+use Simply_Static\Tests\Support\UnitTestCase;
+
+final class ExcludedBackupPage {
+
+	/** @var string */
+	public $url;
+
+	/** @var string|null */
+	public $file_path = 'wp-content/uploads/simply-static/backup-old/studio-backup.zip';
+
+	/** @var string|null */
+	public $last_checked_at;
+
+	/** @var string */
+	public $status_message = '';
+
+	/** @var bool */
+	public $saved = false;
+
+	public function __construct( string $url ) {
+		$this->url = $url;
+	}
+
+	public function set_status_message( string $message ): void {
+		$this->status_message = $message;
+	}
+
+	public function save(): bool {
+		$this->saved = true;
+
+		return true;
+	}
+}
+
+final class FetchUrlsExclusionTest extends UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->requireSource( 'src/class-ss-plugin.php' );
+		$this->requireSource( 'src/class-ss-options.php' );
+		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/tasks/class-ss-task.php' );
+		$this->requireSource( 'src/tasks/traits/class-ss-skip-further-processing-exception.php' );
+		$this->requireSource( 'src/tasks/traits/trait-ss-can-process-pages.php' );
+		$this->requireSource( 'src/tasks/class-ss-fetch-urls-task.php' );
+		Options::instance()->set( 'archive_start_time', '2026-07-13 08:15:32' );
+	}
+
+	public function test_incremental_export_clears_stale_file_path_for_excluded_backup(): void {
+		$key  = str_repeat( 'a', 32 );
+		$page = new ExcludedBackupPage(
+			'https://example.test/wp-content/uploads/simply-static/backup-' . $key . '/studio-backup.zip'
+		);
+
+		$method = new ReflectionMethod( Fetch_Urls_Task::class, 'process_page' );
+		$method->setAccessible( true );
+		$method->invoke( new Fetch_Urls_Task(), $page );
+
+		self::assertNull( $page->file_path );
+		self::assertNotNull( $page->last_checked_at );
+		self::assertTrue( $page->saved );
+		self::assertSame( 'Do not save or follow', $page->status_message );
+	}
+}

--- a/tests/Unit/UploadsCrawlerTest.php
+++ b/tests/Unit/UploadsCrawlerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use ReflectionMethod;
+use Simply_Static\Crawler\Uploads_Crawler;
+use Simply_Static\Tests\Support\UnitTestCase;
+
+final class UploadsCrawlerTest extends UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->requireSource( 'src/class-ss-plugin.php' );
+		$this->requireSource( 'src/class-ss-options.php' );
+		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/crawler/class-ss-crawler.php' );
+		$this->requireSource( 'src/crawler/class-ss-uploads-crawler.php' );
+	}
+
+	public function test_private_backup_files_are_removed_before_upload_urls_are_built(): void {
+		$root       = sys_get_temp_dir() . '/ss-uploads-crawler-' . bin2hex( random_bytes( 8 ) );
+		$backup_dir = $root . '/simply-static/backup-' . str_repeat( 'a', 32 );
+		wp_mkdir_p( $backup_dir );
+		file_put_contents( $root . '/photo.jpg', 'image' );
+		file_put_contents( $backup_dir . '/config.json', '{}' );
+		file_put_contents( $backup_dir . '/studio-backup.zip', 'archive' );
+
+		try {
+			$method = new ReflectionMethod( Uploads_Crawler::class, 'process_file_batch' );
+			$method->setAccessible( true );
+			$urls = $method->invoke(
+				new Uploads_Crawler(),
+				array(
+					new \SplFileInfo( $root . '/photo.jpg' ),
+					new \SplFileInfo( $backup_dir . '/config.json' ),
+					new \SplFileInfo( $backup_dir . '/studio-backup.zip' ),
+				),
+				$root,
+				'https://example.test/wp-content/uploads',
+				array(),
+				array( 'jpg', 'json', 'zip' )
+			);
+
+			self::assertSame( array( 'https://example.test/wp-content/uploads/photo.jpg' ), $urls );
+		} finally {
+			@unlink( $backup_dir . '/config.json' );
+			@unlink( $backup_dir . '/studio-backup.zip' );
+			@unlink( $root . '/photo.jpg' );
+			@rmdir( $backup_dir );
+			@rmdir( dirname( $backup_dir ) );
+			@rmdir( $root );
+		}
+	}
+}

--- a/tests/Unit/UtilSecurityTest.php
+++ b/tests/Unit/UtilSecurityTest.php
@@ -96,6 +96,32 @@ final class UtilSecurityTest extends UnitTestCase {
 		self::assertSame( '', Util::abs_path_to_url( sys_get_temp_dir() . '/outside/export.zip' ) );
 	}
 
+	public function test_private_backup_artifacts_are_excluded_from_discovery_and_stale_queues(): void {
+		$key = str_repeat( 'a', 32 );
+		$url = 'https://example.test/wp-content/uploads/simply-static/backup-' . $key . '/studio-backup-2026-04-10.zip';
+
+		self::assertTrue( Util::is_private_backup_path( $url ) );
+		self::assertTrue( Util::is_private_backup_path( '/simply-static/backup-' . strtoupper( $key ) . '/config.json' ) );
+		self::assertTrue( Util::is_url_excluded( $url ) );
+	}
+
+	/**
+	 * @dataProvider publicSimplyStaticPathProvider
+	 */
+	public function test_public_simply_static_uploads_are_not_mistaken_for_private_backups( string $path ): void {
+		self::assertFalse( Util::is_private_backup_path( $path ) );
+	}
+
+	/** @return array<string,array{string}> */
+	public function publicSimplyStaticPathProvider(): array {
+		return array(
+			'generated config'       => array( '/wp-content/uploads/simply-static/configs/forms.json' ),
+			'legacy archive name'    => array( '/wp-content/uploads/simply-static/studio-backup-2026-04-10.zip' ),
+			'short backup key'       => array( '/wp-content/uploads/simply-static/backup-abc/archive.zip' ),
+			'backup prefix collision' => array( '/wp-content/uploads/simply-static/backup-' . str_repeat( 'a', 32 ) . '-copy/archive.zip' ),
+		);
+	}
+
 	public function test_sensitive_options_are_removed_with_legacy_and_future_key_fallbacks(): void {
 		$options = array(
 			'delivery_method'                 => 'zip',


### PR DESCRIPTION
## Summary
- Excludes Simply Static private backup directories from URL exclusion and uploads crawling.
- Clears stale file paths for previously queued backup pages during incremental exports.
- Adds focused unit coverage and WordPress URL stubs needed by the tests.

## Tests
- ./vendor/bin/phpunit tests/Unit/UtilSecurityTest.php tests/Unit/UploadsCrawlerTest.php tests/Unit/FetchUrlsExclusionTest.php