### PR TITLE
Fix numeric custom page pagination exports

### DIFF
--- a/src/crawler/class-ss-pagination-crawler.php
+++ b/src/crawler/class-ss-pagination-crawler.php
@@ -400,13 +400,14 @@ class Pagination_Crawler extends Crawler {
 		$base_page_path = wp_parse_url( $base_page_url, PHP_URL_PATH );
 		$base_page_path = $base_page_path ? rtrim( $base_page_path, '/' ) : '';
 
-		// Pattern to match pagination links for this specific page
-		// Matches both absolute URLs and relative paths with /page/N/ format
+		// Pattern to match pagination links for this specific page.
+		// WordPress archives commonly use /page/N/, while page-builder widgets
+		// and custom WP_Query instances may use the shorter /N/ format.
 		$patterns = [
-			// Absolute URL pattern: href="https://example.com/articles/page/2/"
-			'#href=["\'](' . preg_quote( rtrim( $base_page_url, '/' ), '#' ) . '/page/(\d+)/?)["\']#i',
-			// Relative path pattern: href="/articles/page/2/"
-			'#href=["\'](' . preg_quote( $base_page_path, '#' ) . '/page/(\d+)/?)["\']#i',
+			// Absolute URL: https://example.com/articles/page/2/ or /articles/2/.
+			'#href=["\'](' . preg_quote( rtrim( $base_page_url, '/' ), '#' ) . '/(?:page/)?(\d+)/?)["\']#i',
+			// Relative path: /articles/page/2/ or /articles/2/.
+			'#href=["\'](' . preg_quote( $base_page_path, '#' ) . '/(?:page/)?(\d+)/?)["\']#i',
 		];
 
 		// Limit the number of pages to scan to prevent infinite loops

--- a/tests/Unit/PaginationCrawlerSecurityTest.php
+++ b/tests/Unit/PaginationCrawlerSecurityTest.php
@@ -44,6 +44,30 @@ final class PaginationCrawlerSecurityTest extends UnitTestCase {
 		}
 	}
 
+	public function test_detects_numeric_custom_page_pagination_urls(): void {
+		WpEnv::$remote_response = array(
+			'response' => array( 'code' => 200 ),
+			'body'     => implode(
+				'',
+				array(
+					'<a href="https://example.test/articles/2/">Page 2</a>',
+					'<a href="/articles/3/">Page 3</a>',
+				)
+			),
+		);
+
+		$urls = $this->extract( 'https://example.test/articles/' );
+
+		self::assertSame(
+			array(
+				'https://example.test/articles/2/',
+				'https://example.test/articles/3/',
+			),
+			$urls
+		);
+		self::assertCount( 3, WpEnv::$remote_requests );
+	}
+
 	public function test_rejects_external_base_url_before_network_io(): void {
 		self::assertSame( array(), $this->extract( 'https://attacker.test/articles/' ) );
 		self::assertSame( array(), WpEnv::$remote_requests );


### PR DESCRIPTION
## Summary
Support both `/page/N/` and `/N/` pagination links when scanning rendered custom pages. This fixes exports for Elementor and other page builders that emit numeric pagination paths while preserving the existing crawler safeguards.

## Tests
- `vendor/bin/phpunit --configuration phpunit.xml.dist` — 281 tests, 4,302 assertions