### PR TITLE
Skip failed pages without cancelling exports

### DIFF
--- a/src/tasks/traits/trait-ss-can-process-pages.php
+++ b/src/tasks/traits/trait-ss-can-process-pages.php
@@ -97,8 +97,7 @@ trait canProcessPages {
 	/**
 	 * Process Pages that have to be processed/transferred.
 	 *
-	 * @return bool|\WP_Error True when done, false when work remains, or an error
-	 *                        when records exhausted their retry allowance.
+	 * @return bool True when done or only skipped records remain, false when work remains.
 	 * @throws \Exception
 	 */
 	public function process_pages() {
@@ -109,23 +108,6 @@ trait canProcessPages {
 		Util::debug_log( "Total pages: " . $total_pages . '; Pages remaining: ' . $pages_to_process_count );
 
 		if ( $pages_to_process_count === 0 ) {
-			$failed_pages = $this->get_exhausted_pages_count();
-			if ( $failed_pages > 0 ) {
-				$message = sprintf(
-					/* translators: %d: number of pages/files that could not be processed. */
-					_n(
-						'%d page or file could not be processed after repeated attempts.',
-						'%d pages or files could not be processed after repeated attempts.',
-						$failed_pages,
-						'simply-static'
-					),
-					$failed_pages
-				);
-				$this->save_status_message( $message, static::$task_name . '_error' );
-
-				return new \WP_Error( 'ss_page_processing_failed', $message, array( 'failed_pages' => $failed_pages ) );
-			}
-
 			$processed_pages = $this->get_processed_pages();
 			$message         = $this->processed_pages_message( $processed_pages, $total_pages );
 			// In 404-only exports, force the transfer log to reflect a single artifact.
@@ -134,6 +116,21 @@ trait canProcessPages {
 				$message = sprintf( __( 'Transferred %d of %d files', 'simply-static' ), 1, 1 );
 			}
 			$this->save_status_message( $message );
+
+			$skipped_pages = $this->get_exhausted_pages_count();
+			if ( $skipped_pages > 0 ) {
+				$skipped_message = sprintf(
+					/* translators: %d: number of skipped pages/files. */
+					_n(
+						'Skipped %d page or file after repeated processing attempts.',
+						'Skipped %d pages or files after repeated processing attempts.',
+						$skipped_pages,
+						'simply-static'
+					),
+					$skipped_pages
+				);
+				$this->save_status_message( $skipped_message, static::$task_name . '_warning' );
+			}
 
 			return true; // No Pages to process anymore. It's done.
 		}

--- a/tests/Unit/PageProcessingFailureTest.php
+++ b/tests/Unit/PageProcessingFailureTest.php
@@ -96,7 +96,7 @@ final class RetryStateTask extends Task {
 		$this->should_fail = $should_fail;
 	}
 
-	/** @return bool|\WP_Error */
+	/** @return bool */
 	public function perform() {
 		return $this->process_pages();
 	}
@@ -146,7 +146,7 @@ final class ExhaustedPagesTask extends Task {
 	/** @var int */
 	public $total_pages = 0;
 
-	/** @return bool|\WP_Error */
+	/** @return bool */
 	public function perform() {
 		return $this->process_pages();
 	}
@@ -184,21 +184,22 @@ final class PageProcessingFailureTest extends UnitTestCase {
 		Options::reinstance();
 	}
 
-	public function test_exhausted_rows_fail_instead_of_reporting_success(): void {
+	public function test_exhausted_rows_are_skipped_without_failing_the_export(): void {
 		$task                  = new ExhaustedPagesTask();
 		$task->failed_pages    = 2;
 		$task->processed_pages = 3;
 		$task->total_pages     = 5;
 
 		$result = $task->perform();
+		$messages = Options::instance()->get( 'archive_status_messages' );
 
-		self::assertInstanceOf( \WP_Error::class, $result );
-		self::assertSame( 'ss_page_processing_failed', $result->get_error_code() );
-		self::assertStringContainsString( '2 pages or files', $result->get_error_message() );
+		self::assertTrue( $result );
+		self::assertStringContainsString( '3 of 5', $messages['task']['message'] );
 		self::assertStringContainsString(
-			'2 pages or files',
-			Options::instance()->get( 'archive_status_messages' )['task_error']['message']
+			'Skipped 2 pages or files',
+			$messages['task_warning']['message']
 		);
+		self::assertArrayNotHasKey( 'task_error', $messages );
 	}
 
 	public function test_empty_queue_is_successful_when_no_rows_failed(): void {
@@ -229,10 +230,7 @@ final class PageProcessingFailureTest extends UnitTestCase {
 		self::assertFalse( $task->perform() );
 		self::assertSame( 3, $page->fetch_attempts );
 
-		$result = $task->perform();
-
-		self::assertInstanceOf( \WP_Error::class, $result );
-		self::assertSame( 'ss_page_processing_failed', $result->get_error_code() );
+		self::assertTrue( $task->perform() );
 		self::assertSame( 'Transient fetch failure', $page->error_message );
 	}
 


### PR DESCRIPTION
## Summary

- Treat pages that exhaust their retry allowance as skipped warnings instead of fatal `WP_Error` results.
- Preserve progress reporting and allow the export to continue into wrap-up while retaining per-page error details.
- Update retry regression tests to cover successful completion with skipped pages.

## Testing

- `vendor/bin/phpunit --configuration phpunit.xml.dist` (288 tests, 4,313 assertions)