### PR TITLE
Bump version to 3.8.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jamstack, performance, security, static site generator
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag:  3.8.0
+Stable tag:  3.8.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -274,6 +274,12 @@ Settings - Configure your static site export options
 Diagnostics - Check your WordPress environment for compatibility
 
 == Changelog ==
+
+= 3.8.1 =
+
+* Fixed exports so failed pages are skipped instead of cancelling the entire export
+* Fixed numeric custom page pagination exports
+* Excluded private backup uploads from exports
 
 = 3.8.0 =
 

--- a/simply-static.php
+++ b/simply-static.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Simply Static
  * Plugin URI:        https://simplystatic.com
  * Description:       A static site generator to create fast and secure static versions of your WordPress website.
- * Version:           3.8.0
+ * Version:           3.8.1
  * Author:            Patrick Posner
  * Author URI:        https://patrickposner.com
  * License:           GPL-2.0+
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'SIMPLY_STATIC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLY_STATIC_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'SIMPLY_STATIC_VERSION', '3.8.0' );
+define( 'SIMPLY_STATIC_VERSION', '3.8.1' );
 
 // Check PHP version.
 if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {

--- a/src/admin/package-lock.json
+++ b/src/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplystatic-settings",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "react-data-table-component": "^8.5.0",

--- a/src/admin/package.json
+++ b/src/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/tests/Unit/BootstrapCompatibilityTest.php
+++ b/tests/Unit/BootstrapCompatibilityTest.php
@@ -99,16 +99,16 @@ namespace Simply_Static\Tests\Unit {
 			$package   = json_decode( (string) file_get_contents( $root . '/src/admin/package.json' ), true );
 			$lock      = json_decode( (string) file_get_contents( $root . '/src/admin/package-lock.json' ), true );
 
-			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.0$/m', $bootstrap );
-			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.0' );", $bootstrap );
+			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.1$/m', $bootstrap );
+			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.1' );", $bootstrap );
 			self::assertStringContainsString( "require_once SIMPLY_STATIC_PATH . 'src/class-ss-pro-compatibility.php';", $bootstrap );
 			self::assertStringContainsString( "add_action( 'plugins_loaded', array( 'Simply_Static\\Pro_Compatibility', 'enforce' ), 1 );", $bootstrap );
 			self::assertStringNotContainsString( 'deactivate_plugins( $pro_basename', $bootstrap );
-			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.0$/m', $readme );
-			self::assertStringContainsString( '= 3.8.0 =', $readme );
-			self::assertSame( '3.8.0', $package['version'] ?? null );
-			self::assertSame( '3.8.0', $lock['version'] ?? null );
-			self::assertSame( '3.8.0', $lock['packages']['']['version'] ?? null );
+			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.1$/m', $readme );
+			self::assertStringContainsString( '= 3.8.1 =', $readme );
+			self::assertSame( '3.8.1', $package['version'] ?? null );
+			self::assertSame( '3.8.1', $lock['version'] ?? null );
+			self::assertSame( '3.8.1', $lock['packages']['']['version'] ?? null );
 		}
 
 		private function registerProRuntimeHooks(): void {


### PR DESCRIPTION
Bumps Simply Static release metadata from 3.8.0 to 3.8.1 across the plugin header, constant, admin package files, and metadata alignment test. Updates the WordPress.org changelog with the failed-page export handling, numeric custom page pagination export fix, and private backup upload exclusion.