### PR TITLE
Preserve runtime Basic Auth options across export saves

### DIFF
--- a/src/class-ss-options.php
+++ b/src/class-ss-options.php
@@ -60,15 +60,7 @@ class Options {
 	public static function instance() {
 		if ( null === self::$instance ) {
 			self::$instance = new self();
-
-			$db_options = get_option( Plugin::SLUG );
-
-			$options = apply_filters( 'ss_get_options', $db_options );
-			if ( ! is_array( $options ) ) {
-				$options = array();
-			}
-
-			self::$instance->options = $options;
+			self::$instance->options = self::load_runtime_options();
 		}
 
 		return self::$instance;
@@ -130,13 +122,20 @@ class Options {
 	 * @return mixed|null
 	 */
 	public function get( $name = '' ) {
-		return array_key_exists( $name, $this->options ) ?
-			(
-			'VERSION' !== strtoupper( $name ) && defined( 'SIMPLY_STATIC_' . strtoupper( $name ) ) ?
-				constant( 'SIMPLY_STATIC_' . strtoupper( $name ) ) :
-				apply_filters( 'ss_get_option_' . strtolower( $name ), $this->options[ $name ], $this )
-			)
-			: null;
+		$normalized_name = strtoupper( $name );
+		$constant_name   = 'SIMPLY_STATIC_' . $normalized_name;
+
+		// Constants are runtime configuration and do not need a placeholder key
+		// in wp_options. This also keeps secret overrides out of database exports.
+		if ( 'VERSION' !== $normalized_name && defined( $constant_name ) ) {
+			return constant( $constant_name );
+		}
+
+		if ( ! array_key_exists( $name, $this->options ) ) {
+			return null;
+		}
+
+		return apply_filters( 'ss_get_option_' . strtolower( $name ), $this->options[ $name ], $this );
 	}
 
 	/**
@@ -191,18 +190,34 @@ class Options {
 
 		$saved = $network ? update_site_option( Plugin::SLUG, $merged ) : update_option( Plugin::SLUG, $merged );
 		if ( ! $saved ) {
-			$stored = $network ? get_site_option( Plugin::SLUG ) : get_option( Plugin::SLUG );
+			$stored = $this->load_current_options_for_merge( $network );
 			$saved  = is_array( $stored ) && $stored === $merged;
 		}
 
 		if ( $saved ) {
-			$this->options      = $merged;
+			// The persisted row deliberately excludes values supplied by runtime
+			// filters. Reload the public option view so those values remain available
+			// to long-running background workers after they save export progress.
+			$this->options      = self::load_runtime_options( $network );
 			$this->dirty_keys   = array();
 			$this->deleted_keys = array();
 			$this->replace_all  = false;
 		}
 
 		return $saved;
+	}
+
+	/**
+	 * Load the filtered runtime option view.
+	 *
+	 * @param bool $network Whether to read the network option.
+	 * @return array
+	 */
+	protected static function load_runtime_options( $network = false ) {
+		$db_options = $network ? get_site_option( Plugin::SLUG ) : get_option( Plugin::SLUG );
+		$options    = apply_filters( 'ss_get_options', $db_options );
+
+		return is_array( $options ) ? $options : array();
 	}
 
 	/**

--- a/tests/Unit/OptionsTest.php
+++ b/tests/Unit/OptionsTest.php
@@ -29,6 +29,40 @@ final class OptionsTest extends UnitTestCase {
 		self::assertFalse( $options->destroy( 'delivery_method' ) );
 	}
 
+	public function test_constant_overrides_do_not_require_a_persisted_option_key(): void {
+		if ( ! defined( 'SIMPLY_STATIC_RUNTIME_ONLY_SETTING' ) ) {
+			define( 'SIMPLY_STATIC_RUNTIME_ONLY_SETTING', 'from-constant' );
+		}
+
+		WpEnv::$options['simply-static'] = array( 'delivery_method' => 'zip' );
+		$options = Options::reinstance();
+
+		self::assertSame( 'from-constant', $options->get( 'runtime_only_setting' ) );
+		self::assertTrue( $options->set( 'archive_start_time', '2026-07-13 18:00:00' )->save() );
+		self::assertSame( 'from-constant', $options->get( 'runtime_only_setting' ) );
+		self::assertArrayNotHasKey( 'runtime_only_setting', WpEnv::$options['simply-static'] );
+	}
+
+	public function test_runtime_filtered_options_remain_available_after_save(): void {
+		add_filter(
+			'ss_get_options',
+			static function ( $options ) {
+				$options = is_array( $options ) ? $options : array();
+				$options['filtered_runtime_setting'] = 'from-filter';
+
+				return $options;
+			}
+		);
+
+		WpEnv::$options['simply-static'] = array( 'delivery_method' => 'zip' );
+		$options = Options::reinstance();
+
+		self::assertSame( 'from-filter', $options->get( 'filtered_runtime_setting' ) );
+		self::assertTrue( $options->set( 'archive_start_time', '2026-07-13 18:00:00' )->save() );
+		self::assertSame( 'from-filter', $options->get( 'filtered_runtime_setting' ) );
+		self::assertArrayNotHasKey( 'filtered_runtime_setting', WpEnv::$options['simply-static'] );
+	}
+
 	public function test_save_merges_only_dirty_keys_into_fresh_database_state(): void {
 		WpEnv::$options['simply-static'] = array(
 			'delivery_method'    => 'zip',

--- a/tests/Unit/UtilSecurityTest.php
+++ b/tests/Unit/UtilSecurityTest.php
@@ -56,6 +56,29 @@ final class UtilSecurityTest extends UnitTestCase {
 		self::assertNull( Util::get_basic_auth_header_for_url( 'https://external.test/page' ) );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_runtime_basic_auth_constants_survive_an_unrelated_option_save(): void {
+		define( 'SIMPLY_STATIC_HTTP_BASIC_AUTH_USERNAME', 'runtime-crawler' );
+		define( 'SIMPLY_STATIC_HTTP_BASIC_AUTH_PASSWORD', 'runtime-password' );
+
+		WpEnv::$options['simply-static'] = array(
+			'delivery_method' => 'zip',
+			'origin_url'      => '',
+		);
+		$options = Options::reinstance();
+
+		self::assertTrue( $options->set( 'archive_start_time', '2026-07-13 18:00:00' )->save() );
+		self::assertSame(
+			'Basic ' . base64_encode( 'runtime-crawler:runtime-password' ),
+			Util::get_basic_auth_header_for_url( 'https://example.test/page' )
+		);
+		self::assertArrayNotHasKey( 'http_basic_auth_username', WpEnv::$options['simply-static'] );
+		self::assertArrayNotHasKey( 'http_basic_auth_password', WpEnv::$options['simply-static'] );
+	}
+
 	public function test_empty_credentials_never_create_an_authorization_header(): void {
 		WpEnv::$options['simply-static']['http_basic_auth_username'] = '';
 		WpEnv::$options['simply-static']['http_basic_auth_password'] = '';


### PR DESCRIPTION
Runtime option loading now honors `SIMPLY_STATIC_*` constants without requiring persisted placeholder keys and restores filtered values after export progress saves. Save verification reads the raw persisted option state so runtime-only values do not cause false failures or leak into the database. Regression tests cover constant-only options, filtered runtime options, and Basic Auth headers surviving unrelated saves while credentials remain absent from `wp_options`. Verified with `composer test` (291 tests, 4,325 assertions).