### PR TITLE
Allow local redirect targets

### DIFF
--- a/tests/Unit/RedirectViewSecurityTest.php
+++ b/tests/Unit/RedirectViewSecurityTest.php
@@ -19,6 +19,30 @@ final class RedirectViewSecurityTest extends UnitTestCase {
 		self::assertStringContainsString( 'one=1&amp;two=2', $html );
 	}
 
+	/** @dataProvider relativeTargetProvider */
+	public function test_relative_redirect_targets_emit_navigation( string $url ): void {
+		$html = $this->render( $url );
+
+		self::assertStringContainsString(
+			'window.location.assign(' . wp_json_encode( $url ) . ')',
+			$html
+		);
+		self::assertStringContainsString( 'content="0;url=' . esc_attr( $url ) . '"', $html );
+		self::assertStringContainsString( 'href="' . esc_attr( $url ) . '"', $html );
+		self::assertStringNotContainsString( 'The redirect target is invalid.', $html );
+	}
+
+	/** @return array<string,array{string}> */
+	public function relativeTargetProvider(): array {
+		return array(
+			'root relative'     => array( '/en/' ),
+			'configured prefix' => array( '/docs/en/?preview=1#top' ),
+			'offline'           => array( './en/' ),
+			'parent directory'  => array( '../en/' ),
+			'path relative'     => array( 'en/' ),
+		);
+	}
+
 	/** @dataProvider unsafeTargetProvider */
 	public function test_unsafe_redirect_targets_do_not_emit_navigation( string $url ): void {
 		$html = $this->render( $url );
@@ -30,11 +54,14 @@ final class RedirectViewSecurityTest extends UnitTestCase {
 	/** @return array<string,array{string}> */
 	public function unsafeTargetProvider(): array {
 		return array(
-			'javascript' => array( 'javascript:alert(1)' ),
-			'userinfo'   => array( 'https://attacker@example.test/private' ),
-			'zero user'  => array( 'https://0@example.test/private' ),
-			'file'       => array( 'file:///etc/passwd' ),
-			'relative'   => array( '/admin-only' ),
+			'javascript'        => array( 'javascript:alert(1)' ),
+			'userinfo'          => array( 'https://attacker@example.test/private' ),
+			'zero user'         => array( 'https://0@example.test/private' ),
+			'file'              => array( 'file:///etc/passwd' ),
+			'protocol relative' => array( '//attacker.example/private' ),
+			'backslash host'    => array( '\\\\attacker.example/private' ),
+			'mixed slash host'  => array( '/\\attacker.example/private' ),
+			'control byte'      => array( "/en/\nnext" ),
 		);
 	}
 

--- a/views/redirect.php
+++ b/views/redirect.php
@@ -1,15 +1,33 @@
 <?php
-$redirect_url   = esc_url_raw( (string) $this->redirect_url );
-$redirect_parts = wp_parse_url( $redirect_url );
-if (
-	! is_array( $redirect_parts )
-	|| empty( $redirect_parts['host'] )
-	|| empty( $redirect_parts['scheme'] )
-	|| ! in_array( strtolower( $redirect_parts['scheme'] ), array( 'http', 'https' ), true )
-	|| array_key_exists( 'user', $redirect_parts )
-	|| array_key_exists( 'pass', $redirect_parts )
-) {
-	$redirect_url = '';
+$redirect_url      = (string) $this->redirect_url;
+$redirect_parts    = wp_parse_url( $redirect_url );
+
+// Relative and offline exports intentionally create path-only redirect targets.
+// Keep those local by rejecting protocol-relative and backslash-based URLs.
+$is_relative_url   = is_array( $redirect_parts )
+	&& ! empty( $redirect_parts['path'] )
+	&& ! array_key_exists( 'scheme', $redirect_parts )
+	&& ! array_key_exists( 'host', $redirect_parts )
+	&& ! array_key_exists( 'user', $redirect_parts )
+	&& ! array_key_exists( 'pass', $redirect_parts )
+	&& 0 !== strpos( $redirect_url, '//' )
+	&& false === strpos( $redirect_url, '\\' )
+	&& ! preg_match( '/[\x00-\x20\x7F]/', $redirect_url );
+
+if ( ! $is_relative_url ) {
+	$redirect_url   = esc_url_raw( $redirect_url );
+	$redirect_parts = wp_parse_url( $redirect_url );
+
+	if (
+		! is_array( $redirect_parts )
+		|| empty( $redirect_parts['host'] )
+		|| empty( $redirect_parts['scheme'] )
+		|| ! in_array( strtolower( $redirect_parts['scheme'] ), array( 'http', 'https' ), true )
+		|| array_key_exists( 'user', $redirect_parts )
+		|| array_key_exists( 'pass', $redirect_parts )
+	) {
+		$redirect_url = '';
+	}
 }
 ?>
 <!DOCTYPE html>
@@ -17,7 +35,7 @@ if (
 	<head>
 		<title><?php echo esc_html__( 'Redirecting...', 'simply-static' ); ?></title>
 			<?php if ( $redirect_url ) : ?>
-				<meta http-equiv="refresh" content="0;url=<?php echo esc_attr( esc_url( $redirect_url ) ); ?>">
+				<meta http-equiv="refresh" content="0;url=<?php echo esc_attr( $redirect_url ); ?>">
 			<?php endif; ?>
 	</head>
 	<body>
@@ -28,7 +46,7 @@ if (
 			<?php endif; ?>
 
 			<?php if ( $redirect_url ) : ?>
-				<p><?php echo wp_kses_post( sprintf( __( 'You are being redirected to %s', 'simply-static' ), '<a href="' . esc_url( $redirect_url ) . '">' . esc_html( $redirect_url ) . '</a>' ) ); ?></p>
+				<p><?php echo wp_kses_post( sprintf( __( 'You are being redirected to %s', 'simply-static' ), '<a href="' . esc_attr( $redirect_url ) . '">' . esc_html( $redirect_url ) . '</a>' ) ); ?></p>
 			<?php else : ?>
 				<p><?php echo esc_html__( 'The redirect target is invalid.', 'simply-static' ); ?></p>
 			<?php endif; ?>


### PR DESCRIPTION
Allows relative and offline redirect targets to render navigation while preserving validation for absolute URLs. Rejects protocol-relative, backslash-based, credentialed, unsupported-scheme, and control-character targets. Adds unit coverage for accepted local redirect forms and rejected unsafe forms.\n\nTests: composer test