### PR TITLE
Fix relative URL path handling

### DIFF
--- a/src/class-ss-options.php
+++ b/src/class-ss-options.php
@@ -284,7 +284,7 @@ class Options {
 				return untrailingslashit( $this->get( 'destination_scheme' ) . $this->get( 'destination_host' ) );
 				break;
 			case 'relative':
-				return $this->get( 'relative_path' );
+				return untrailingslashit( (string) $this->get( 'relative_path' ) );
 		}
 
 		return './';

--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -1757,10 +1757,8 @@ class Url_Extractor {
 		// Get the appropriate replacement URL based on destination URL type
 		switch ( $this->options->get( 'destination_url_type' ) ) {
 			case 'absolute':
-				$convert_to = $this->options->get_destination_url();
-				break;
 			case 'relative':
-				$convert_to = $this->options->get( 'relative_path' );
+				$convert_to = $this->options->get_destination_url();
 				break;
 			default:
 				// Offline mode
@@ -2293,8 +2291,9 @@ class Url_Extractor {
 	private function convert_relative_url( $url ) {
 		$path           = Util::get_public_path_from_local_url( $url );
 		$sanitized_path = Util::sanitize_local_path( $path );
+		$relative_path  = $this->options->get_destination_url();
 
-		return $this->options->get( 'relative_path' ) . $sanitized_path;
+		return Util::safe_join_url( $relative_path, $sanitized_path );
 	}
 
 	/**

--- a/tests/Unit/OptionsTest.php
+++ b/tests/Unit/OptionsTest.php
@@ -169,6 +169,14 @@ final class OptionsTest extends UnitTestCase {
 				array( 'destination_url_type' => 'relative', 'relative_path' => '/docs' ),
 				'/docs',
 			),
+			'root relative' => array(
+				array( 'destination_url_type' => 'relative', 'relative_path' => '/' ),
+				'',
+			),
+			'trailing slash relative' => array(
+				array( 'destination_url_type' => 'relative', 'relative_path' => '/docs/' ),
+				'/docs',
+			),
 			'offline' => array( array( 'destination_url_type' => 'offline' ), './' ),
 		);
 	}

--- a/tests/Unit/UrlExtractorTest.php
+++ b/tests/Unit/UrlExtractorTest.php
@@ -121,10 +121,22 @@ final class UrlExtractorTest extends UnitTestCase {
 
 	public function test_relative_and_offline_destination_modes_produce_local_paths(): void {
 		WpEnv::$options['simply-static']['destination_url_type'] = 'relative';
+		WpEnv::$options['simply-static']['relative_path'] = '/';
 		Options::reinstance();
-		$relative = $this->extractor( 'html', '<a href="/target/">target</a>' );
+		$relative = $this->extractor( 'html', '<a href="https://example.test/target/">target</a>' );
+		self::assertSame( '/target/', $relative->convert_url( 'https://example.test/target/' ) );
+		self::assertSame(
+			'window.site = "/tc/";',
+			$relative->force_replace( 'window.site = "https://example.test/tc/";' )
+		);
 		$relative->extract_and_update_urls();
 		self::assertStringContainsString( 'href="/target/"', $relative->get_body() );
+		self::assertStringNotContainsString( 'href="//target/"', $relative->get_body() );
+
+		WpEnv::$options['simply-static']['relative_path'] = '/docs/';
+		Options::reinstance();
+		$mounted = $this->extractor( 'html', '<a href="https://example.test/target/">target</a>' );
+		self::assertSame( '/docs/target/', $mounted->convert_url( 'https://example.test/target/' ) );
 
 		WpEnv::$options['simply-static']['destination_url_type'] = 'offline';
 		Options::reinstance();


### PR DESCRIPTION
## Summary
- Normalize configured relative destination paths with trailing slashes removed.
- Reuse destination URL handling for relative replacements and safely join converted relative URLs.
- Add unit coverage for root and mounted relative paths.

## Tests
- vendor/bin/phpunit --configuration phpunit.xml.dist tests/Unit/OptionsTest.php tests/Unit/UrlExtractorTest.php