### PR TITLE
Add atomic export start gate

### DIFF
--- a/src/admin/inc/class-ss-admin-rest.php
+++ b/src/admin/inc/class-ss-admin-rest.php
@@ -1674,15 +1674,18 @@ class Admin_Rest {
 					) );
 				}
 
-				if ( ! empty( $language ) ) {
-					update_option( 'simply-static-use-language', $language, false );
-				} else {
-					delete_option( 'simply-static-use-language' );
-				}
+				$prepare_export = function () use ( $blog_id, $type, $language, $archive_creation_job ) {
+					if ( ! empty( $language ) ) {
+						update_option( 'simply-static-use-language', $language, false );
+					} else {
+						delete_option( 'simply-static-use-language' );
+					}
 
-				do_action( 'ss_before_perform_archive_action', $blog_id, 'start', $archive_creation_job );
-				$export_type = apply_filters( 'ss_export_type', $type );
-				$started = Plugin::instance()->run_static_export( $blog_id, $export_type );
+					do_action( 'ss_before_perform_archive_action', $blog_id, 'start', $archive_creation_job );
+
+					return apply_filters( 'ss_export_type', $type );
+				};
+				$started = Plugin::instance()->run_static_export( $blog_id, $type, $prepare_export );
 				if ( $started ) {
 					do_action( 'ss_after_perform_archive_action', $blog_id, 'start', $archive_creation_job );
 					return wp_json_encode( array( 'status' => 200 ) );

--- a/src/admin/inc/class-ss-admin-settings.php
+++ b/src/admin/inc/class-ss-admin-settings.php
@@ -39,31 +39,29 @@ class Admin_Settings {
 			}
 		};
 
-        // Ensure generate_404 option is enabled via UI gating; proceed regardless.
-        update_option( 'simply-static-404-only', 1, false );
+		try {
+			$prepare_export = static function () {
+				// Mutate the 404 scope only after Core owns the atomic export start gate.
+				update_option( 'simply-static-404-only', 1, false );
+				delete_option( 'simply-static-use-single' );
+				delete_option( 'simply-static-use-build' );
+				delete_option( 'simply-static-use-language' );
 
-        // Clear conflicting flags that could alter the task list.
-        delete_option( 'simply-static-use-single' );
-        delete_option( 'simply-static-use-build' );
-        delete_option( 'simply-static-use-language' );
-
-        try {
-			$started = Plugin::instance()->run_static_export();
+				return 'export';
+			};
+			$started = Plugin::instance()->run_static_export( 0, 'export', $prepare_export, $restore_flags );
 			if ( ! $started ) {
-				$restore_flags();
-
 				return array(
 					'success' => false,
 					'message' => __( 'The 404 export could not be started because another export is active or an export preflight check failed.', 'simply-static' ),
 				);
 			}
 
-            return [ 'success' => true ];
-        } catch ( \Throwable $e ) {
-			$restore_flags();
-            return [ 'success' => false, 'message' => $e->getMessage() ];
-        }
-    }
+			return [ 'success' => true ];
+		} catch ( \Throwable $e ) {
+			return [ 'success' => false, 'message' => $e->getMessage() ];
+		}
+	}
 
     /**
      * Contains the number of failed tests.

--- a/src/class-ss-plugin.php
+++ b/src/class-ss-plugin.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * The core plugin class
  */
 class Plugin {
+	/** Option used as an atomic gate while an export request is being prepared. */
+	const EXPORT_START_LOCK_OPTION = 'simply-static-export-start-lock';
 
 	/**
 	 * The slug of the plugin; used in actions, filters, i18n, table names, etc.
@@ -63,6 +65,13 @@ class Plugin {
 	 * @var null|\Simply_Static\Integrations
 	 */
 	protected $integrations = null;
+
+	/**
+	 * Token owned by this request while it prepares and starts an export.
+	 *
+	 * @var string
+	 */
+	protected $export_start_lock_token = '';
 
 
 	/**
@@ -243,70 +252,191 @@ class Plugin {
 	/**
 	 * Handle static export.
 	 *
-	 * @param int $blog_id given blog id.
+	 * @param int           $blog_id         Given blog ID.
+	 * @param string        $type            Export type.
+	 * @param callable|null $prepare_callback Optional scope preparation callback. It
+	 *                                        runs only after the atomic start gate is
+	 *                                        held and the archive job is confirmed idle.
+	 * @param callable|null $failure_callback Optional rollback callback invoked under
+	 *                                        the same gate when preparation started but
+	 *                                        the export could not be started.
 	 *
 	 * @return bool Whether the export was started successfully
 	 */
-	public function run_static_export( $blog_id = 0, $type = 'export' ) {
-		// Check if an export is already running
-		if ( $this->archive_creation_job->is_running() ) {
-			Util::debug_log( "Export already running. Blocking new export request." );
-			Util::debug_log( "Current task: " . $this->archive_creation_job->get_current_task() );
-			Util::debug_log( "Is job done: " . ($this->archive_creation_job->is_job_done() ? 'true' : 'false') );
-
-			// For cron jobs or programmatic calls, we just return without starting a new export
-			// The REST API endpoints will handle their own error responses
+	public function run_static_export( $blog_id = 0, $type = 'export', $prepare_callback = null, $failure_callback = null ) {
+		if ( ! $this->acquire_export_start_lock() ) {
+			Util::debug_log( 'Export start blocked because another request is preparing an export.' );
 			return false;
 		}
 
-		// PHP_AUTH_USER and an explicit Basic Authorization scheme are reliable
-		// Basic Auth signals. REMOTE_USER/AUTH_USER may instead come from SSO,
-		// Kerberos, or a reverse proxy and must not block otherwise valid exports.
-		$basic_auth_on = isset( $_SERVER['PHP_AUTH_USER'] )
-			&& is_string( $_SERVER['PHP_AUTH_USER'] )
-			&& '' !== $_SERVER['PHP_AUTH_USER'];
-		foreach ( array( 'HTTP_AUTHORIZATION', 'REDIRECT_HTTP_AUTHORIZATION' ) as $authorization_key ) {
-			if (
-				isset( $_SERVER[ $authorization_key ] )
-				&& is_string( $_SERVER[ $authorization_key ] )
-				&& preg_match( '/^\s*Basic\s+/i', $_SERVER[ $authorization_key ] )
-			) {
-				$basic_auth_on = true;
-				break;
+		$preparation_started = false;
+		try {
+			// This check must happen while the start gate is held. Otherwise two PHP
+			// requests can both observe an idle job before either one persists its scope.
+			if ( $this->is_export_active() ) {
+				Util::debug_log( "Export already running. Blocking new export request." );
+				if ( method_exists( $this->archive_creation_job, 'get_current_task' ) ) {
+					Util::debug_log( "Current task: " . $this->archive_creation_job->get_current_task() );
+				}
+				if ( method_exists( $this->archive_creation_job, 'is_job_done' ) ) {
+					Util::debug_log( "Is job done: " . ($this->archive_creation_job->is_job_done() ? 'true' : 'false') );
+				}
+
+				return false;
 			}
+
+			// PHP_AUTH_USER and an explicit Basic Authorization scheme are reliable
+			// Basic Auth signals. REMOTE_USER/AUTH_USER may instead come from SSO,
+			// Kerberos, or a reverse proxy and must not block otherwise valid exports.
+			$basic_auth_on = isset( $_SERVER['PHP_AUTH_USER'] )
+				&& is_string( $_SERVER['PHP_AUTH_USER'] )
+				&& '' !== $_SERVER['PHP_AUTH_USER'];
+			foreach ( array( 'HTTP_AUTHORIZATION', 'REDIRECT_HTTP_AUTHORIZATION' ) as $authorization_key ) {
+				if (
+					isset( $_SERVER[ $authorization_key ] )
+					&& is_string( $_SERVER[ $authorization_key ] )
+					&& preg_match( '/^\s*Basic\s+/i', $_SERVER[ $authorization_key ] )
+				) {
+					$basic_auth_on = true;
+					break;
+				}
+			}
+
+			// Exit if Basic Auth but no credentials were provided.
+			if ( $basic_auth_on ) {
+				$options         = get_option( 'simply-static' );
+				$options         = is_array( $options ) ? $options : array();
+				$basic_auth_user = isset( $options['http_basic_auth_username'] ) ? $options['http_basic_auth_username'] : '';
+				$basic_auth_pass = isset( $options['http_basic_auth_password'] ) ? $options['http_basic_auth_password'] : '';
+
+				$credentials_configured = is_string( $basic_auth_user )
+					&& is_string( $basic_auth_pass )
+					&& '' !== $basic_auth_user
+					&& '' !== $basic_auth_pass;
+
+				if ( ! $credentials_configured ) {
+					// Reject the export before dispatching background work. Starting and
+					// immediately cancelling left stale queue and archive state behind.
+					$message = __( 'Missing Basic Auth credentials - you need to configure the Basic Auth credentials in Simply Static -> Settings -> Misc -> Basic Auth to continue the export.', 'simply-static' );
+					$this->archive_creation_job->save_status_message( $message, 'error' );
+					return false;
+				}
+			}
+
+			if ( ! $blog_id ) {
+				$blog_id = get_current_blog_id();
+			}
+
+			if ( is_callable( $prepare_callback ) ) {
+				$preparation_started = true;
+				$prepared_type = call_user_func( $prepare_callback, $blog_id, $type, $this->archive_creation_job );
+				if ( false === $prepared_type || is_wp_error( $prepared_type ) ) {
+					$this->rollback_failed_export_start( $failure_callback );
+					$preparation_started = false;
+					return false;
+				}
+				if ( is_string( $prepared_type ) && '' !== $prepared_type ) {
+					$type = $prepared_type;
+				}
+			}
+
+			do_action( 'ss_before_static_export', $blog_id, $type );
+
+			// Clear transients.
+			Util::clear_transients();
+
+			// Start export only after all preflight validation and atomic scope
+			// preparation succeeds.
+			$started = (bool) $this->archive_creation_job->start( $blog_id, $type );
+			if ( ! $started && $preparation_started ) {
+				$this->rollback_failed_export_start( $failure_callback );
+				$preparation_started = false;
+			}
+
+			return $started;
+		} catch ( \Throwable $exception ) {
+			if ( $preparation_started ) {
+				$this->rollback_failed_export_start( $failure_callback );
+			}
+
+			throw $exception;
+		} finally {
+			$this->release_export_start_lock();
+		}
+	}
+
+	/** Run a supplied scope rollback without masking the original start result. */
+	protected function rollback_failed_export_start( $failure_callback ) {
+		if ( ! is_callable( $failure_callback ) ) {
+			return;
 		}
 
-		// Exit if Basic Auth but no credentials were provided.
-		if ( $basic_auth_on ) {
-			$options         = get_option( 'simply-static' );
-			$options         = is_array( $options ) ? $options : array();
-			$basic_auth_user = isset( $options['http_basic_auth_username'] ) ? $options['http_basic_auth_username'] : '';
-			$basic_auth_pass = isset( $options['http_basic_auth_password'] ) ? $options['http_basic_auth_password'] : '';
+		try {
+			call_user_func( $failure_callback );
+		} catch ( \Throwable $exception ) {
+			Util::debug_log( 'Export start rollback failed: ' . $exception->getMessage() );
+		}
+	}
 
-			$credentials_configured = is_string( $basic_auth_user )
-				&& is_string( $basic_auth_pass )
-				&& '' !== $basic_auth_user
-				&& '' !== $basic_auth_pass;
+	/** Return whether any running, paused, or queued export owns the archive state. */
+	public function is_export_active() {
+		$job = $this->archive_creation_job;
+		return ( method_exists( $job, 'is_running' ) && $job->is_running() )
+			|| ( method_exists( $job, 'is_paused' ) && $job->is_paused() )
+			|| ( method_exists( $job, 'is_queued' ) && $job->is_queued() );
+	}
 
-			if ( ! $credentials_configured ) {
-				// Reject the export before dispatching background work. Starting and
-				// immediately cancelling left stale queue and archive state behind.
-				$message = __( 'Missing Basic Auth credentials - you need to configure the Basic Auth credentials in Simply Static -> Settings -> Misc -> Basic Auth to continue the export.', 'simply-static' );
-				$this->archive_creation_job->save_status_message( $message, 'error' );
+	/**
+	 * Atomically reserve the short export preparation/start window.
+	 *
+	 * The database uniqueness constraint behind add_option() makes this safe
+	 * across PHP workers. Locks older than five minutes are treated as abandoned.
+	 *
+	 * @return bool
+	 */
+	public function acquire_export_start_lock() {
+		if ( '' !== $this->export_start_lock_token ) {
+			// A nested start in the same PHP request is still a competing start and
+			// must not prepare a second scope before the first one is persisted.
+			return false;
+		}
+
+		$token = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( 'ss_export_', true );
+		$lock  = array(
+			'token'      => $token,
+			'created_at' => time(),
+		);
+
+		if ( ! add_option( self::EXPORT_START_LOCK_OPTION, $lock, '', false ) ) {
+			$existing = get_option( self::EXPORT_START_LOCK_OPTION );
+			$created  = is_array( $existing ) && isset( $existing['created_at'] ) ? (int) $existing['created_at'] : 0;
+			if ( $created > 0 && ( time() - $created ) <= 300 ) {
+				return false;
+			}
+
+			// Recover from a PHP process that died while holding the short gate.
+			delete_option( self::EXPORT_START_LOCK_OPTION );
+			if ( ! add_option( self::EXPORT_START_LOCK_OPTION, $lock, '', false ) ) {
 				return false;
 			}
 		}
 
-		if ( ! $blog_id ) {
-			$blog_id = get_current_blog_id();
+		$this->export_start_lock_token = $token;
+		return true;
+	}
+
+	/** Release the export start gate when it is still owned by this request. */
+	public function release_export_start_lock() {
+		if ( '' === $this->export_start_lock_token ) {
+			return;
 		}
-		do_action( 'ss_before_static_export', $blog_id, $type );
 
-		// Clear transients.
-		Util::clear_transients();
+		$existing = get_option( self::EXPORT_START_LOCK_OPTION );
+		if ( is_array( $existing ) && isset( $existing['token'] ) && hash_equals( $this->export_start_lock_token, (string) $existing['token'] ) ) {
+			delete_option( self::EXPORT_START_LOCK_OPTION );
+		}
 
-		// Start export only after all preflight validation succeeds.
-		return (bool) $this->archive_creation_job->start( $blog_id, $type );
+		$this->export_start_lock_token = '';
 	}
 
 	/**

--- a/tests/Support/wordpress-stubs.php
+++ b/tests/Support/wordpress-stubs.php
@@ -133,6 +133,15 @@ function get_option( $key, $default = false ) {
 	return array_key_exists( $key, WpEnv::$options ) ? WpEnv::$options[ $key ] : $default;
 }
 
+function add_option( $key, $value, $deprecated = '', $autoload = 'yes' ) {
+	if ( array_key_exists( $key, WpEnv::$options ) ) {
+		return false;
+	}
+
+	WpEnv::$options[ $key ] = $value;
+	return true;
+}
+
 function update_option( $key, $value, $autoload = null ) {
 	WpEnv::$options[ $key ] = $value;
 	return true;

--- a/tests/Unit/ExportLifecycleTest.php
+++ b/tests/Unit/ExportLifecycleTest.php
@@ -21,6 +21,12 @@ final class ExportLifecycleArchiveJob {
 	public $running = false;
 
 	/** @var bool */
+	public $paused = false;
+
+	/** @var bool */
+	public $queued = false;
+
+	/** @var bool */
 	public $start_result = true;
 
 	/** @var array<int,array{int,string}> */
@@ -31,6 +37,14 @@ final class ExportLifecycleArchiveJob {
 
 	public function is_running(): bool {
 		return $this->running;
+	}
+
+	public function is_paused(): bool {
+		return $this->paused;
+	}
+
+	public function is_queued(): bool {
+		return $this->queued;
 	}
 
 	public function get_current_task(): string {
@@ -157,6 +171,127 @@ final class ExportLifecycleTest extends UnitTestCase {
 
 		self::assertFalse( $this->plugin->run_static_export( 3, 'export' ) );
 		self::assertSame( array( array( 3, 'export' ) ), $this->job->starts );
+	}
+
+	public function test_contended_start_gate_blocks_preparation_without_mutating_scope(): void {
+		WpEnv::$options[ Plugin::EXPORT_START_LOCK_OPTION ] = array(
+			'token'      => 'another-request',
+			'created_at' => time(),
+		);
+		WpEnv::$options['simply-static-use-build'] = 17;
+		$prepare_calls = 0;
+
+		$started = $this->plugin->run_static_export(
+			1,
+			'export',
+			static function () use ( &$prepare_calls ) {
+				++$prepare_calls;
+				update_option( 'simply-static-use-build', 29, false );
+				return 'export';
+			}
+		);
+
+		self::assertFalse( $started );
+		self::assertSame( 0, $prepare_calls );
+		self::assertSame( 17, WpEnv::$options['simply-static-use-build'] );
+		self::assertSame( array(), $this->job->starts );
+	}
+
+	public function test_active_or_paused_jobs_block_preparation_and_release_the_gate(): void {
+		$prepare_calls = 0;
+		$prepare = static function () use ( &$prepare_calls ) {
+			++$prepare_calls;
+			return 'export';
+		};
+
+		$this->job->running = true;
+		self::assertFalse( $this->plugin->run_static_export( 1, 'export', $prepare ) );
+		$this->job->running = false;
+		$this->job->paused  = true;
+		self::assertFalse( $this->plugin->run_static_export( 1, 'export', $prepare ) );
+
+		self::assertSame( 0, $prepare_calls );
+		self::assertArrayNotHasKey( Plugin::EXPORT_START_LOCK_OPTION, WpEnv::$options );
+	}
+
+	public function test_preparation_can_atomically_select_type_and_success_releases_gate(): void {
+		$gate_seen = false;
+		$started = $this->plugin->run_static_export(
+			8,
+			'42',
+			static function () use ( &$gate_seen ) {
+				$gate_seen = array_key_exists( Plugin::EXPORT_START_LOCK_OPTION, WpEnv::$options );
+				update_option( 'simply-static-use-build', 42, false );
+				return 'export';
+			}
+		);
+
+		self::assertTrue( $started );
+		self::assertTrue( $gate_seen );
+		self::assertSame( array( array( 8, 'export' ) ), $this->job->starts );
+		self::assertSame( 42, WpEnv::$options['simply-static-use-build'] );
+		self::assertArrayNotHasKey( Plugin::EXPORT_START_LOCK_OPTION, WpEnv::$options );
+	}
+
+	public function test_failed_start_rolls_back_prepared_scope_before_releasing_gate(): void {
+		$this->job->start_result = false;
+		WpEnv::$options['simply-static-use-single'] = '11';
+		$rollback_saw_gate = false;
+
+		$started = $this->plugin->run_static_export(
+			3,
+			'export',
+			static function () {
+				update_option( 'simply-static-use-single', '22', false );
+				return 'export';
+			},
+			static function () use ( &$rollback_saw_gate ) {
+				$rollback_saw_gate = array_key_exists( Plugin::EXPORT_START_LOCK_OPTION, WpEnv::$options );
+				update_option( 'simply-static-use-single', '11', false );
+			}
+		);
+
+		self::assertFalse( $started );
+		self::assertTrue( $rollback_saw_gate );
+		self::assertSame( '11', WpEnv::$options['simply-static-use-single'] );
+		self::assertArrayNotHasKey( Plugin::EXPORT_START_LOCK_OPTION, WpEnv::$options );
+	}
+
+	public function test_abandoned_or_malformed_start_gate_is_recovered(): void {
+		foreach (
+			array(
+				array( 'token' => 'stale', 'created_at' => time() - 301 ),
+				'corrupt',
+			) as $stale_lock
+		) {
+			WpEnv::$options[ Plugin::EXPORT_START_LOCK_OPTION ] = $stale_lock;
+			self::assertTrue( $this->plugin->run_static_export( 2, 'export' ) );
+			self::assertArrayNotHasKey( Plugin::EXPORT_START_LOCK_OPTION, WpEnv::$options );
+		}
+	}
+
+	public function test_nested_start_in_same_request_is_rejected_before_its_preparation(): void {
+		$nested_prepare_calls = 0;
+		$outer_started = $this->plugin->run_static_export(
+			5,
+			'export',
+			function () use ( &$nested_prepare_calls ) {
+				$nested_started = $this->plugin->run_static_export(
+					5,
+					'export',
+					static function () use ( &$nested_prepare_calls ) {
+						++$nested_prepare_calls;
+						return 'export';
+					}
+				);
+				self::assertFalse( $nested_started );
+				return 'export';
+			}
+		);
+
+		self::assertTrue( $outer_started );
+		self::assertSame( 0, $nested_prepare_calls );
+		self::assertCount( 1, $this->job->starts );
 	}
 
 	public function test_page_handlers_register_before_init_and_run_after_integration_bootstrap(): void {


### PR DESCRIPTION
Adds an atomic export start lock so concurrent requests cannot mutate export scope before the archive job is reserved. Moves REST and 404 export scope preparation into callbacks that run only after the gate is held, with rollback support on failed starts. Treats running, paused, and queued jobs as active export state. Adds unit coverage for lock contention, stale lock recovery, rollback, nested starts, and prepared export type selection.