### PR TITLE
Bump Simply Static to 3.8.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jamstack, performance, security, static site generator
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag:  3.8.2
+Stable tag:  3.8.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -274,6 +274,11 @@ Settings - Configure your static site export options
 Diagnostics - Check your WordPress environment for compatibility
 
 == Changelog ==
+
+= 3.8.3 =
+
+* Prevented concurrent export requests from overwriting each other's export scope
+* Fixed relative URL path handling
 
 = 3.8.2 =
 

--- a/simply-static.php
+++ b/simply-static.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Simply Static
  * Plugin URI:        https://simplystatic.com
  * Description:       A static site generator to create fast and secure static versions of your WordPress website.
- * Version:           3.8.2
+ * Version:           3.8.3
  * Author:            Patrick Posner
  * Author URI:        https://patrickposner.com
  * License:           GPL-2.0+
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'SIMPLY_STATIC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLY_STATIC_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'SIMPLY_STATIC_VERSION', '3.8.2' );
+define( 'SIMPLY_STATIC_VERSION', '3.8.3' );
 
 // Check PHP version.
 if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {

--- a/src/admin/package-lock.json
+++ b/src/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplystatic-settings",
-      "version": "3.8.2",
+      "version": "3.8.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "react-data-table-component": "^8.5.0",

--- a/src/admin/package.json
+++ b/src/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/tests/Unit/BootstrapCompatibilityTest.php
+++ b/tests/Unit/BootstrapCompatibilityTest.php
@@ -53,6 +53,7 @@ namespace Simply_Static\Tests\Unit {
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.0' ) );
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.1' ) );
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.2' ) );
+			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.3' ) );
 		}
 
 		public function test_outdated_active_pro_is_left_active_but_all_runtime_hooks_are_blocked(): void {
@@ -100,16 +101,16 @@ namespace Simply_Static\Tests\Unit {
 			$package   = json_decode( (string) file_get_contents( $root . '/src/admin/package.json' ), true );
 			$lock      = json_decode( (string) file_get_contents( $root . '/src/admin/package-lock.json' ), true );
 
-			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.2$/m', $bootstrap );
-			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.2' );", $bootstrap );
+			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.3$/m', $bootstrap );
+			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.3' );", $bootstrap );
 			self::assertStringContainsString( "require_once SIMPLY_STATIC_PATH . 'src/class-ss-pro-compatibility.php';", $bootstrap );
 			self::assertStringContainsString( "add_action( 'plugins_loaded', array( 'Simply_Static\\Pro_Compatibility', 'enforce' ), 1 );", $bootstrap );
 			self::assertStringNotContainsString( 'deactivate_plugins( $pro_basename', $bootstrap );
-			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.2$/m', $readme );
-			self::assertStringContainsString( '= 3.8.2 =', $readme );
-			self::assertSame( '3.8.2', $package['version'] ?? null );
-			self::assertSame( '3.8.2', $lock['version'] ?? null );
-			self::assertSame( '3.8.2', $lock['packages']['']['version'] ?? null );
+			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.3$/m', $readme );
+			self::assertStringContainsString( '= 3.8.3 =', $readme );
+			self::assertSame( '3.8.3', $package['version'] ?? null );
+			self::assertSame( '3.8.3', $lock['version'] ?? null );
+			self::assertSame( '3.8.3', $lock['packages']['']['version'] ?? null );
 		}
 
 		private function registerProRuntimeHooks(): void {


### PR DESCRIPTION
## Summary
- Bump the plugin, stable tag, and admin package metadata to 3.8.3.
- Document the concurrent export protection and relative URL fixes included since 3.8.2.
- Align bootstrap and compatibility assertions with the release metadata.

## Testing
- composer test (307 tests, 4,384 assertions)