### PR TITLE
Fix inline background process continuation

### DIFF
--- a/src/background/class-ss-background-process.php
+++ b/src/background/class-ss-background-process.php
@@ -104,6 +104,13 @@ abstract class Background_Process extends Async_Request {
 	protected $is_inline = false;
 
 	/**
+	 * Whether an inline shutdown continuation has already been registered.
+	 *
+	 * @var bool
+	 */
+	protected $inline_dispatch_pending = false;
+
+	/**
 	 * Value written to the current process lock by this PHP process.
 	 *
 	 * @var string|null
@@ -393,14 +400,15 @@ abstract class Background_Process extends Async_Request {
 	 * @return bool True to indicate inline dispatch was scheduled.
 	 */
 	protected function dispatch_inline() {
-		// A dispatch requested from inside the current shutdown worker must be
-		// recovered by the scheduled healthcheck. Registering another shutdown
-		// callback here makes PHP run every batch in one FPM request.
-		if ( $this->is_inline ) {
+		// Multiple callers can request a continuation before shutdown begins.
+		// Keep a single pending callback, while allowing the callback itself to
+		// schedule the next bounded worker window when queue work remains.
+		if ( $this->inline_dispatch_pending ) {
 			return true;
 		}
 
-		$this->is_inline = true;
+		$this->is_inline               = true;
+		$this->inline_dispatch_pending = true;
 
 		// Prevent wp_die() from terminating the shutdown function.
 		// handle() calls maybe_wp_die() at the end, which would otherwise
@@ -410,7 +418,19 @@ abstract class Background_Process extends Async_Request {
 		$process        = $this;
 		$target_site_id = $this->current_site_id;
 
-		register_shutdown_function( function () use ( $process, $target_site_id ) {
+		$this->register_inline_shutdown_handler( function () use ( $process, $target_site_id ) {
+			// Release the pending slot before handling. If handle() reaches its
+			// time or memory boundary with work left, dispatch_inline() can now
+			// register exactly one immediate continuation.
+			$process->inline_dispatch_pending = false;
+
+			// A paused queue must remain dormant until resume() explicitly
+			// dispatches it again. Continuing inline here would spin through
+			// shutdown callbacks without doing useful work.
+			if ( $process->is_paused() ) {
+				return;
+			}
+
 			$switched = is_multisite()
 				&& ! empty( $target_site_id )
 				&& absint( $target_site_id ) !== get_current_blog_id();
@@ -449,6 +469,19 @@ abstract class Background_Process extends Async_Request {
 		} );
 
 		return true;
+	}
+
+	/**
+	 * Register an inline worker callback for PHP shutdown.
+	 *
+	 * Kept as a method so continuation scheduling can be covered without
+	 * executing real shutdown callbacks in the unit-test process.
+	 *
+	 * @param callable $handler Inline worker callback.
+	 * @return void
+	 */
+	protected function register_inline_shutdown_handler( $handler ) {
+		register_shutdown_function( $handler );
 	}
 
 	/**

--- a/tests/Unit/BackgroundProcessStateTest.php
+++ b/tests/Unit/BackgroundProcessStateTest.php
@@ -225,6 +225,38 @@ final class BackgroundDispatchProcess extends BackgroundStateProcess {
 
 }
 
+final class BackgroundInlineContinuationProcess extends BackgroundStateProcess {
+
+	/** @var callable[] */
+	public $shutdown_handlers = array();
+
+	/** @var int */
+	public $handle_calls = 0;
+
+	public function is_processing() {
+		return false;
+	}
+
+	/** @return bool */
+	public function schedule_inline() {
+		return parent::dispatch_inline();
+	}
+
+	/** @param callable $handler */
+	protected function register_inline_shutdown_handler( $handler ) {
+		$this->shutdown_handlers[] = $handler;
+	}
+
+	protected function handle() {
+		++$this->handle_calls;
+		parent::dispatch_inline();
+	}
+
+	public function run_shutdown_handler( int $index ): void {
+		call_user_func( $this->shutdown_handlers[ $index ] );
+	}
+}
+
 final class BackgroundLoopbackProcess extends BackgroundStateProcess {
 
 	/** @var bool|null */
@@ -738,6 +770,30 @@ final class BackgroundProcessStateTest extends UnitTestCase {
 		self::assertTrue( $process->dispatch_via_background() );
 		self::assertSame( 'no', WpEnv::$site_transients['wp_state_process_loopback_available'] );
 		self::assertSame( 1, $process->inline_calls );
+	}
+
+	public function test_inline_fallback_keeps_one_pending_handler_and_immediately_continues(): void {
+		$process = new BackgroundInlineContinuationProcess();
+
+		self::assertTrue( $process->schedule_inline() );
+		self::assertTrue( $process->schedule_inline() );
+		self::assertCount( 1, $process->shutdown_handlers );
+
+		$process->run_shutdown_handler( 0 );
+
+		self::assertSame( 1, $process->handle_calls );
+		self::assertCount( 2, $process->shutdown_handlers );
+	}
+
+	public function test_inline_fallback_does_not_continue_a_paused_queue(): void {
+		$process = new BackgroundInlineContinuationProcess();
+		update_option( $process->status_key(), Background_Process::STATUS_PAUSED );
+
+		self::assertTrue( $process->schedule_inline() );
+		$process->run_shutdown_handler( 0 );
+
+		self::assertSame( 0, $process->handle_calls );
+		self::assertCount( 1, $process->shutdown_handlers );
 	}
 
 	public function test_loopback_detection_uses_override_cache_status_and_failure_cache(): void {


### PR DESCRIPTION
## Summary
- Track pending inline shutdown callbacks separately so duplicate dispatch requests only register one handler.
- Allow an active inline handler to schedule one immediate continuation when work remains, while skipping continuation for paused queues.
- Add unit coverage for bounded inline continuation and paused queue behavior.

## Tests
- composer test -- --filter BackgroundProcessStateTest