### PR TITLE
Preserve SVG data URIs during CSS URL extraction

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -1614,17 +1614,22 @@ class Url_Extractor {
 		// Pass 1: Handle url(...) constructs with quoted or unquoted values, including relative URLs.
 		// Pattern breakdown:
 		// - url( optional whitespace
-		// - capture the url(...) value, then normalize quote placeholders inside
+		// - prefer a complete quoted value, allowing escaped quotes and parentheses
+		// - otherwise capture an unquoted value up to its closing parenthesis
+		// - normalize quote placeholders inside
 		//   the callback. This prevents preserved entities like APOS_PLACEHOLDER
-		//   from being appended to extracted Gutenberg background-image URLs.
+		//   from being appended to extracted Gutenberg background-image URLs. Matching
+		//   the complete quoted value also prevents functions inside SVG data URIs
+		//   (for example rgb(...)) from being mistaken for the end of url(...).
 		$text = preg_replace_callback(
-			'/url\(\s*([^\)]*?)\s*\)/i',
+			'/url\(\s*(?:(?<quote>["\'])(?<quoted>(?:\\\\.|(?!\k<quote>).)*)\k<quote>|(?<unquoted>(?:\\\\.|[^)\\\\])*))\s*\)/is',
 			function ( $m ) use ( $charset ) {
-				$raw   = trim( $m[1] );
-				$quote = '';
+				$quote = isset( $m['quote'] ) ? $m['quote'] : '';
+				$raw   = $quote !== '' && isset( $m['quoted'] ) ? $m['quoted'] : ( isset( $m['unquoted'] ) ? $m['unquoted'] : '' );
+				$raw   = trim( $raw );
 				$val   = $raw;
 
-				if ( $raw !== '' ) {
+				if ( $quote === '' && $raw !== '' ) {
 					$first_char = $raw[0];
 					$last_char  = substr( $raw, -1 );
 

--- a/tests/Unit/UrlExtractorTest.php
+++ b/tests/Unit/UrlExtractorTest.php
@@ -104,6 +104,18 @@ final class UrlExtractorTest extends UnitTestCase {
 		self::assertStringContainsString( 'https://static.example.test/base.css', $extractor->get_body() );
 	}
 
+	public function test_css_svg_data_uri_preserves_namespace_url(): void {
+		$css = '.search{background-image:url("data:image/svg+xml,<svg xmlns=\\"http://www.w3.org/2000/svg\\" '
+			. 'width=\\"24\\" height=\\"24\\" fill=\\"none\\" stroke=\\"rgb(136, 145, 164)\\">'
+			. '<circle cx=\\"11\\" cy=\\"11\\" r=\\"8\\"></circle></svg>")}'
+			. '.select{mask-image:url("data:image/svg+xml,%3Csvg xmlns=\\"http://www.w3.org/2000/svg\\"%3E%3C/svg%3E")}';
+		$extractor = $this->extractor( 'css', $css, 'assets/site.css' );
+
+		$extractor->extract_and_update_urls();
+
+		self::assertSame( $css, $extractor->get_body() );
+	}
+
 	public function test_json_and_xml_urls_are_replaced_without_touching_external_origins(): void {
 		$json = '{"local":"https:\/\/example.test\/api\/items","external":"https:\/\/external.test\/api"}';
 		$json_extractor = $this->extractor( 'json', $json, 'data.json' );


### PR DESCRIPTION
## Summary

Fixes CSS url() parsing so quoted SVG data URIs with nested parentheses are consumed as complete values. This prevents namespace URLs such as http://www.w3.org/2000/svg from being normalized to http:/www.w3.org/2000/svg. Adds regression coverage for raw and percent-encoded SVG data URIs.

## Testing

- composer test (310 tests, 4,393 assertions)