### PR TITLE
Fix large CSS SVG data URI parsing

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -1620,12 +1620,23 @@ class Url_Extractor {
 		//   the callback. This prevents preserved entities like APOS_PLACEHOLDER
 		//   from being appended to extracted Gutenberg background-image URLs. Matching
 		//   the complete quoted value also prevents functions inside SVG data URIs
-		//   (for example rgb(...)) from being mistaken for the end of url(...).
-		$text = preg_replace_callback(
-			'/url\(\s*(?:(?<quote>["\'])(?<quoted>(?:\\\\.|(?!\k<quote>).)*)\k<quote>|(?<unquoted>(?:\\\\.|[^)\\\\])*))\s*\)/is',
+		//   (for example rgb(...)) from being mistaken for the end of url(...). The
+		//   quote-specific branches consume ordinary characters in chunks so large
+		//   inline SVGs do not exhaust PCRE's backtracking or JIT stack limits.
+		$_result = preg_replace_callback(
+			'~url\(\s*(?:(?<double_quote>")(?<double>[^"\\\\]*+(?:\\\\.[^"\\\\]*+)*+)"|(?<single_quote>\')(?<single>[^\'\\\\]*+(?:\\\\.[^\'\\\\]*+)*+)\'|(?<unquoted>[^)\\\\]*+(?:\\\\.[^)\\\\]*+)*+))\s*\)~is',
 			function ( $m ) use ( $charset ) {
-				$quote = isset( $m['quote'] ) ? $m['quote'] : '';
-				$raw   = $quote !== '' && isset( $m['quoted'] ) ? $m['quoted'] : ( isset( $m['unquoted'] ) ? $m['unquoted'] : '' );
+				if ( isset( $m['double_quote'] ) && $m['double_quote'] === '"' ) {
+					$quote = '"';
+					$raw   = isset( $m['double'] ) ? $m['double'] : '';
+				} else if ( isset( $m['single_quote'] ) && $m['single_quote'] === "'" ) {
+					$quote = "'";
+					$raw   = isset( $m['single'] ) ? $m['single'] : '';
+				} else {
+					$quote = '';
+					$raw   = isset( $m['unquoted'] ) ? $m['unquoted'] : '';
+				}
+
 				$raw   = trim( $raw );
 				$val   = $raw;
 
@@ -1666,10 +1677,13 @@ class Url_Extractor {
 			},
 			$text
 		);
+		if ( null !== $_result ) {
+			$text = $_result;
+		}
 
 		// Pass 2: Fallback - replace any remaining bare local absolute or protocol-relative URLs by converting them.
 		$escaped_origin = preg_quote( Util::origin_host(), '/' );
-		$text           = preg_replace_callback(
+		$_result        = preg_replace_callback(
 			'/((?:https?:)?\/\/' . $escaped_origin . ')[^"\')\s;,]+/i',
 			function ( $m ) {
 				$matched_url = $m[0];
@@ -1679,6 +1693,9 @@ class Url_Extractor {
 			},
 			$text
 		);
+		if ( null !== $_result ) {
+			$text = $_result;
+		}
 
 		// Pass 3: Fix HTML numeric entities used inside CSS content strings (e.g., content: "&#61710;" from Elementor/EAEL)
 		// Browsers do not decode HTML entities inside CSS. Convert these to proper CSS escapes like \f10e.

--- a/tests/Unit/UrlExtractorTest.php
+++ b/tests/Unit/UrlExtractorTest.php
@@ -94,14 +94,17 @@ final class UrlExtractorTest extends UnitTestCase {
 	}
 
 	public function test_css_imports_and_urls_are_extracted_and_rewritten(): void {
-		$css = '@import url("../base.css"); .a{background:url(./image.png)} .b{src:url(https://external.test/font.woff2)}';
+		$css = '@import url("../base.css"); .a{background:url(./image.png)} .b{src:url(https://external.test/font.woff2)}'
+			. ".c{background:url('../single.png')}";
 		$extractor = $this->extractor( 'css', $css, 'assets/site.css' );
 		$urls = $extractor->extract_and_update_urls();
 
 		self::assertContains( 'https://example.test/base.css', $urls );
 		self::assertContains( 'https://example.test/blog/image.png', $urls );
+		self::assertContains( 'https://example.test/single.png', $urls );
 		self::assertNotContains( 'https://external.test/font.woff2', $urls );
 		self::assertStringContainsString( 'https://static.example.test/base.css', $extractor->get_body() );
+		self::assertStringContainsString( "url('https://static.example.test/single.png')", $extractor->get_body() );
 	}
 
 	public function test_css_svg_data_uri_preserves_namespace_url(): void {
@@ -114,6 +117,20 @@ final class UrlExtractorTest extends UnitTestCase {
 		$extractor->extract_and_update_urls();
 
 		self::assertSame( $css, $extractor->get_body() );
+	}
+
+	public function test_large_css_svg_data_uri_does_not_empty_stylesheet(): void {
+		$path = str_repeat( 'M0 0L1 1', 4000 );
+		$css  = '.icon{background-image:url("data:image/svg+xml,<svg xmlns=\\"http://www.w3.org/2000/svg\\">'
+			. '<path d=\\"' . $path . '\\"></path></svg>")}.after{background-image:url("../after.png")}';
+		$expected  = str_replace( '../after.png', 'https://static.example.test/after.png', $css );
+		$extractor = $this->extractor( 'css', $css, 'assets/large-svg.css' );
+
+		$extractor->extract_and_update_urls();
+
+		$body = $extractor->get_body();
+		self::assertSame( strlen( $expected ), strlen( $body ) );
+		self::assertSame( hash( 'sha256', $expected ), hash( 'sha256', $body ) );
 	}
 
 	public function test_json_and_xml_urls_are_replaced_without_touching_external_origins(): void {


### PR DESCRIPTION
## Summary
- Parse quoted CSS `url()` values with quote-specific, chunked patterns so large inline SVGs do not exhaust PCRE limits.
- Preserve both quote styles and retain the existing CSS whenever a regex replacement fails.
- Add regression coverage for single-quoted URLs and a roughly 32 KB SVG data URI followed by a normal asset URL.

## Testing
- `composer test` — 315 tests and 4,407 assertions passed; the reporter-supplied 31,986-byte gist also remained byte-identical after extraction.