### PR TITLE
Fix subdirectory asset export paths

### DIFF
--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -1896,21 +1896,9 @@ class Util {
 
 		$base = self::get_local_url_base( self::remove_params_and_fragment( $url ) );
 		if ( null !== $base ) {
-			$url_parts  = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url );
-			$base_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $base ) : parse_url( $base );
-
-			if ( is_array( $url_parts ) && is_array( $base_parts ) ) {
-				$url_path  = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
-				$base_path = isset( $base_parts['path'] ) ? untrailingslashit( $base_parts['path'] ) : '';
-
-				if ( '' !== $base_path && '/' !== $base_path ) {
-					$url_path = substr( $url_path, strlen( $base_path ) );
-				}
-
-				$query    = isset( $url_parts['query'] ) ? '?' . $url_parts['query'] : '';
-				$fragment = isset( $url_parts['fragment'] ) ? '#' . $url_parts['fragment'] : '';
-
-				return '/' . ltrim( $url_path, '/' ) . $query . $fragment;
+			$path = self::get_path_from_url_base( $url, $base );
+			if ( null !== $path ) {
+				return $path;
 			}
 		}
 
@@ -1930,9 +1918,113 @@ class Util {
 	 * @return string
 	 */
 	public static function get_public_path_from_local_url( $url ) {
-		$path = self::get_path_from_local_url( $url );
+		$source_path = self::get_path_from_local_url( $url );
+		$public_path = self::replace_wordpress_path_with_public_path( $source_path );
 
-		return self::replace_wordpress_path_with_public_path( $path );
+		if (
+			! is_string( $source_path )
+			|| ! self::is_root_wordpress_asset_path( self::remove_params_and_fragment( $source_path ) )
+		) {
+			return $public_path;
+		}
+
+		$asset_prefix = self::get_public_asset_path_prefix( $url, $source_path );
+		if ( '' === $asset_prefix ) {
+			return $public_path;
+		}
+
+		return $asset_prefix . '/' . ltrim( $public_path, '/' );
+	}
+
+	/**
+	 * Get the WordPress install path that must prefix a generated asset path.
+	 *
+	 * Local URL matching intentionally prefers the longest base so redirects
+	 * between an Origin URL, home_url(), and site_url() can resolve to the same
+	 * generated page. For assets, however, a deeper WordPress Address is a real
+	 * public path when the Site Address is its parent. Preserve that suffix in
+	 * the generated path instead of treating it as another export root.
+	 *
+	 * @param string $url Absolute local asset URL.
+	 * @param string $source_path Asset path relative to the matched local base.
+	 *
+	 * @return string Path prefix, or an empty string when none should be added.
+	 */
+	private static function get_public_asset_path_prefix( $url, $source_path ) {
+		if ( ! is_string( $url ) || ! is_string( $source_path ) ) {
+			return '';
+		}
+
+		$public_bases = array( self::origin_url() );
+		if ( function_exists( 'home_url' ) ) {
+			$public_bases[] = untrailingslashit( home_url() );
+		}
+
+		$public_bases = array_values( array_unique( array_filter( array_map( 'untrailingslashit', $public_bases ) ) ) );
+		$source_path = self::remove_params_and_fragment( $source_path );
+
+		foreach ( $public_bases as $public_base ) {
+			$public_root_path = self::get_path_from_url_base( $url, $public_base );
+			if ( null === $public_root_path ) {
+				continue;
+			}
+
+			$public_root_path = self::remove_params_and_fragment( $public_root_path );
+			if ( $public_root_path === $source_path || strlen( $public_root_path ) <= strlen( $source_path ) ) {
+				return '';
+			}
+
+			if ( substr( $public_root_path, -strlen( $source_path ) ) !== $source_path ) {
+				return '';
+			}
+
+			return rtrim( substr( $public_root_path, 0, -strlen( $source_path ) ), '/' );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get a URL path relative to one explicit local base.
+	 *
+	 * @param string $url URL to normalize.
+	 * @param string $base Local base URL.
+	 *
+	 * @return string|null Relative path, or null when the base does not match.
+	 */
+	private static function get_path_from_url_base( $url, $base ) {
+		$url_parts  = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url );
+		$base_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $base ) : parse_url( $base );
+
+		if ( ! is_array( $url_parts ) || ! is_array( $base_parts ) || empty( $url_parts['host'] ) || empty( $base_parts['host'] ) ) {
+			return null;
+		}
+
+		if ( self::normalize_url_host( $url_parts['host'] ) !== self::normalize_url_host( $base_parts['host'] ) ) {
+			return null;
+		}
+
+		$url_path  = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
+		$base_path = isset( $base_parts['path'] ) ? untrailingslashit( $base_parts['path'] ) : '';
+
+		if (
+			'' !== $base_path
+			&& '/' !== $base_path
+			&& $url_path !== $base_path
+			&& 0 !== strpos( untrailingslashit( $url_path ) . '/', trailingslashit( $base_path ) )
+		) {
+			return null;
+		}
+
+		if ( '' !== $base_path && '/' !== $base_path ) {
+			$url_path = substr( $url_path, strlen( $base_path ) );
+			$url_path = '' === $url_path ? '/' : $url_path;
+		}
+
+		$query    = isset( $url_parts['query'] ) ? '?' . $url_parts['query'] : '';
+		$fragment = isset( $url_parts['fragment'] ) ? '#' . $url_parts['fragment'] : '';
+
+		return '/' . ltrim( $url_path, '/' ) . $query . $fragment;
 	}
 
 	/**

--- a/tests/Unit/UrlExtractorTest.php
+++ b/tests/Unit/UrlExtractorTest.php
@@ -9,6 +9,8 @@ use Simply_Static\Page;
 use Simply_Static\Tests\Support\UnitTestCase;
 use Simply_Static\Tests\Support\WpTestEnvironment as WpEnv;
 use Simply_Static\Url_Extractor;
+use Simply_Static\Url_Fetcher;
+use Simply_Static\Util;
 
 final class UrlExtractorTest extends UnitTestCase {
 
@@ -25,6 +27,8 @@ final class UrlExtractorTest extends UnitTestCase {
 		$this->requireSource( 'src/class-ss-query.php' );
 		$this->requireSource( 'src/models/class-ss-model.php' );
 		$this->requireSource( 'src/models/class-ss-page.php' );
+		$this->requireSource( 'src/handlers/class-ss-page-handler.php' );
+		$this->requireSource( 'src/class-ss-url-fetcher.php' );
 		$this->requireSource( 'src/class-ss-url-extractor.php' );
 
 		$base = WpEnv::$upload_dir['basedir'] . '/simply-static/url-extractor';
@@ -155,6 +159,78 @@ final class UrlExtractorTest extends UnitTestCase {
 		$offline = $this->extractor( 'html', '<a href="/target/">target</a>' );
 		$offline->extract_and_update_urls();
 		self::assertStringContainsString( 'target/index.html', $offline->get_body() );
+	}
+
+	public function test_relative_exports_preserve_wordpress_install_subdirectory_for_assets(): void {
+		WpEnv::$home_url = 'https://example.test';
+		WpEnv::$site_url = 'https://example.test/wordpress';
+		WpEnv::$options['simply-static']['destination_url_type'] = 'relative';
+		WpEnv::$options['simply-static']['relative_path'] = '/';
+		WpEnv::$options['simply-static']['wp_content_directory'] = 'wp-content';
+		WpEnv::$options['simply-static']['wp_includes_directory'] = 'wp-includes';
+		Options::reinstance();
+
+		$content_url  = 'https://example.test/wordpress/wp-content/themes/site/style.css';
+		$includes_url = 'https://example.test/wordpress/wp-includes/js/jquery/jquery.min.js';
+
+		// Redirect comparisons still normalize alternate WordPress URL bases.
+		self::assertSame( '/wp-content/themes/site/style.css', Util::get_path_from_local_url( $content_url ) );
+		self::assertSame( '/wp-includes/js/jquery/jquery.min.js', Util::get_path_from_local_url( $includes_url ) );
+
+		// Export paths retain the WordPress Address suffix relative to the public Site Address.
+		self::assertSame( '/wordpress/wp-content/themes/site/style.css', Util::get_public_path_from_local_url( $content_url ) );
+		self::assertSame( '/wordpress/wp-includes/js/jquery/jquery.min.js', Util::get_public_path_from_local_url( $includes_url ) );
+
+		$fetcher_ref = new \ReflectionClass( Url_Fetcher::class );
+		$fetcher     = $fetcher_ref->newInstanceWithoutConstructor();
+		$archive_dir = $fetcher_ref->getProperty( 'archive_dir' );
+		$archive_dir->setAccessible( true );
+		$archive_dir->setValue( $fetcher, $this->archive_dir );
+		$asset_page = Page::initialize( array(
+			'url'              => $content_url,
+			'http_status_code' => 200,
+			'content_type'     => 'text/css',
+		) );
+
+		self::assertSame(
+			'wordpress/wp-content/themes/site/style.css',
+			$fetcher->create_directories_for_static_page( $asset_page )
+		);
+
+		$relative = $this->extractor( 'html', '<link rel="stylesheet" href="' . $content_url . '"><script src="' . $includes_url . '"></script>' );
+		self::assertSame( '/wordpress/wp-content/themes/site/style.css', $relative->convert_url( $content_url ) );
+		self::assertSame( '/wordpress/wp-includes/js/jquery/jquery.min.js', $relative->convert_url( $includes_url ) );
+
+		$relative->extract_and_update_urls();
+		self::assertStringContainsString( 'href="/wordpress/wp-content/themes/site/style.css"', $relative->get_body() );
+		self::assertStringContainsString( 'src="/wordpress/wp-includes/js/jquery/jquery.min.js"', $relative->get_body() );
+	}
+
+	public function test_subdirectory_asset_prefix_composes_with_hide_wordpress_directories(): void {
+		WpEnv::$home_url = 'https://example.test';
+		WpEnv::$site_url = 'https://example.test/wordpress';
+		WpEnv::$options['simply-static']['wp_content_directory'] = 'assets';
+		WpEnv::$options['simply-static']['wp_includes_directory'] = 'core';
+		Options::reinstance();
+
+		self::assertSame(
+			'/wordpress/assets/themes/site/style.css',
+			Util::get_public_path_from_local_url( 'https://example.test/wordpress/wp-content/themes/site/style.css' )
+		);
+		self::assertSame(
+			'/wordpress/core/js/jquery/jquery.min.js',
+			Util::get_public_path_from_local_url( 'https://example.test/wordpress/wp-includes/js/jquery/jquery.min.js' )
+		);
+
+		WpEnv::$home_url = 'https://example.test/wordpress';
+		WpEnv::$options['simply-static']['wp_content_directory'] = 'wp-content';
+		WpEnv::$options['simply-static']['wp_includes_directory'] = 'wp-includes';
+		Options::reinstance();
+
+		self::assertSame(
+			'/wp-content/themes/site/style.css',
+			Util::get_public_path_from_local_url( 'https://example.test/wordpress/wp-content/themes/site/style.css' )
+		);
 	}
 
 	private function extractor( string $type, string $body, string $file_path = 'page.html' ): Url_Extractor {


### PR DESCRIPTION
Preserve the WordPress installation subdirectory when generating public paths for wp-content and wp-includes assets while keeping alternate local URL-base normalization intact. Reuse explicit base-relative path parsing and compose the preserved prefix with Hide WP directory remapping. Add regression coverage for static file placement, relative URL conversion and rewriting, root installs, and remapped asset directories.\n\nTests: vendor/bin/phpunit (316 tests, 4415 assertions).