### PR TITLE
Normalize transfer path separators

### DIFF
--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -2494,6 +2494,7 @@ class Util {
 	 * @return string Sanitized path.
 	 */
 	public static function sanitize_path( $path ) {
+		$path               = self::normalize_slashes( (string) $path );
 		$segments           = explode( '/', $path );
 		$sanitized_segments = array_map( [ self::class, 'sanitize_filename' ], $segments );
 
@@ -2676,7 +2677,7 @@ class Util {
 	 * @param string $path File path to remove trailing directory separators from
 	 */
 	public static function remove_trailing_directory_separator( $path ) {
-		return rtrim( $path, DIRECTORY_SEPARATOR );
+		return rtrim( (string) $path, "/\\" );
 	}
 
 	/**
@@ -2689,7 +2690,7 @@ class Util {
 			return '';
 		}
 
-		return ltrim( $path, DIRECTORY_SEPARATOR );
+		return ltrim( (string) $path, "/\\" );
 	}
 
 	/**

--- a/src/tasks/traits/trait-ss-can-transfer.php
+++ b/src/tasks/traits/trait-ss-can-transfer.php
@@ -9,6 +9,10 @@ trait canTransfer {
 	 * @return string
 	 */
 	protected function get_page_file_path( $static_page ) {
-		return apply_filters( 'ss_get_page_file_path_for_transfer', $static_page->file_path, $static_page );
+		$file_path = apply_filters( 'ss_get_page_file_path_for_transfer', $static_page->file_path, $static_page );
+
+		// Transfer paths are always archive-relative, regardless of the host OS or
+		// the separator style returned by an integration/filter.
+		return ltrim( Util::normalize_slashes( (string) $file_path ), '/' );
 	}
 }

--- a/tests/Unit/UtilSecurityTest.php
+++ b/tests/Unit/UtilSecurityTest.php
@@ -17,6 +17,7 @@ final class UtilSecurityTest extends UnitTestCase {
 		$this->requireSource( 'src/class-ss-options.php' );
 		$this->requireSource( 'src/class-ss-phpuri.php' );
 		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/tasks/traits/trait-ss-can-transfer.php' );
 
 		WpEnv::$options['simply-static'] = array(
 			'http_basic_auth_username' => 'crawler',
@@ -24,6 +25,31 @@ final class UtilSecurityTest extends UnitTestCase {
 			'origin_url'               => '',
 		);
 		Options::reinstance();
+	}
+
+	public function test_path_helpers_normalize_both_directory_separator_styles(): void {
+		self::assertSame( 'assets/site/index.html', Util::remove_leading_directory_separator( '/\\assets/site/index.html' ) );
+		self::assertSame( 'assets/site', Util::remove_trailing_directory_separator( 'assets/site/\\' ) );
+		self::assertSame( 'assets/site/', Util::sanitize_path( 'assets\\site\\' ) );
+	}
+
+	public function test_transfer_paths_are_portable_and_archive_relative(): void {
+		$transfer = new class() {
+			use \Simply_Static\canTransfer;
+
+			public function page_file_path( $page ): string {
+				return $this->get_page_file_path( $page );
+			}
+		};
+
+		self::assertSame(
+			'assets/site/index.html',
+			$transfer->page_file_path( (object) array( 'file_path' => '\\assets\\site\\index.html' ) )
+		);
+		self::assertSame(
+			'assets/site/index.html',
+			$transfer->page_file_path( (object) array( 'file_path' => '/assets/site/index.html' ) )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Normalizes path helpers and transfer file paths so mixed Windows and Unix separators are handled consistently. Transfer paths are now forced to archive-relative forward-slash paths after filters run. Adds unit coverage for both helper normalization and portable transfer paths.