### PR TITLE
Prevent internal page IDs from leaking into exported URLs

### DIFF
--- a/src/class-ss-page-handlers.php
+++ b/src/class-ss-page-handlers.php
@@ -80,5 +80,29 @@ class Page_Handlers {
 		$handler->run_hooks();
 
 		do_action( 'simply_static_page_handler_request_after_hooks', $handler );
+
+		$this->remove_page_id_from_request_uri();
+	}
+
+	/**
+	 * Remove the internal page identifier from the public request URL.
+	 *
+	 * The query argument is needed long enough to resolve and initialize the
+	 * page handler. Leaving it in REQUEST_URI after that point allows plugins
+	 * which serialize the current request URL to expose the internal identifier
+	 * in the generated static page. Keep $_GET intact for integrations which use
+	 * it to detect a Simply Static request.
+	 *
+	 * @return void
+	 */
+	protected function remove_page_id_from_request_uri() {
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) || ! is_string( $_SERVER['REQUEST_URI'] ) ) {
+			return;
+		}
+
+		$_SERVER['REQUEST_URI'] = remove_query_arg(
+			'simply_static_page',
+			wp_unslash( $_SERVER['REQUEST_URI'] )
+		);
 	}
 }

--- a/tests/Unit/PageHandlersRequestTest.php
+++ b/tests/Unit/PageHandlersRequestTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use Simply_Static\Page_Handlers;
+use Simply_Static\Tests\Support\UnitTestCase;
+
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-page-handlers.php';
+
+final class RequestUriPageHandler {
+
+	/** @var string|null */
+	public $request_uri;
+
+	public function run_hooks(): void {
+		$this->request_uri = $_SERVER['REQUEST_URI'] ?? null;
+	}
+}
+
+final class RequestUriPage {
+
+	/** @var RequestUriPageHandler */
+	private $handler;
+
+	public function __construct( RequestUriPageHandler $handler ) {
+		$this->handler = $handler;
+	}
+
+	public function get_handler(): RequestUriPageHandler {
+		return $this->handler;
+	}
+}
+
+final class RequestUriPageHandlers extends Page_Handlers {
+
+	/** @var RequestUriPage */
+	private $page;
+
+	public function __construct( RequestUriPage $page ) {
+		$this->page = $page;
+		parent::__construct();
+	}
+
+	public function includes() {
+		// The request lifecycle test supplies its own handler.
+	}
+
+	public function get_static_page() {
+		return $this->page;
+	}
+}
+
+final class PageHandlersRequestTest extends UnitTestCase {
+
+	/**
+	 * @dataProvider requestUriProvider
+	 */
+	public function test_internal_page_id_is_hidden_from_later_request_url_consumers(
+		string $request_uri,
+		string $expected_uri
+	): void {
+		$original_get             = $_GET;
+		$had_original_request_uri = array_key_exists( 'REQUEST_URI', $_SERVER );
+		$original_request_uri     = $_SERVER['REQUEST_URI'] ?? null;
+
+		try {
+			$_GET['simply_static_page'] = '59229';
+			$_SERVER['REQUEST_URI']      = $request_uri;
+
+			$handler = new RequestUriPageHandler();
+			new RequestUriPageHandlers( new RequestUriPage( $handler ) );
+
+			$later_request_uri = null;
+			add_action(
+				'init',
+				static function () use ( &$later_request_uri ): void {
+					$later_request_uri = $_SERVER['REQUEST_URI'] ?? null;
+				},
+				PHP_INT_MAX
+			);
+
+			do_action( 'init' );
+
+			self::assertSame( $request_uri, $handler->request_uri );
+			self::assertSame( $expected_uri, $later_request_uri );
+			self::assertSame( '59229', $_GET['simply_static_page'] );
+		} finally {
+			$_GET = $original_get;
+			if ( $had_original_request_uri ) {
+				$_SERVER['REQUEST_URI'] = $original_request_uri;
+			} else {
+				unset( $_SERVER['REQUEST_URI'] );
+			}
+		}
+	}
+
+	/** @return array<string,array{string,string}> */
+	public function requestUriProvider(): array {
+		return array(
+			'root page' => array(
+				'/?simply_static_page=59229',
+				'/',
+			),
+			'page with preceding query argument' => array(
+				'/news/?lang=de&simply_static_page=59229',
+				'/news/?lang=de',
+			),
+			'page with following query argument' => array(
+				'/news/?simply_static_page=59229&preview=1',
+				'/news/?preview=1',
+			),
+			'page with surrounding query arguments' => array(
+				'/news/?lang=de&simply_static_page=59229&preview=1',
+				'/news/?lang=de&preview=1',
+			),
+		);
+	}
+}


### PR DESCRIPTION
Removes the internal simply_static_page argument from REQUEST_URI after export page-handler hooks run, while keeping $_GET intact for integration detection. This prevents plugins such as Optimization Detective from serializing internal database IDs into static output and preserves legitimate query parameters. Adds lifecycle regression coverage for root and query-string pages. Tests: composer test (323 tests, 4,436 assertions).