### PR TITLE
Improve static export resource discovery

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -981,6 +981,97 @@ class Url_Extractor {
 	}
 
 	/**
+	 * Remove WordPress REST discovery links when REST routes are not exported.
+	 *
+	 * @param DOMXPath $xpath XPath instance for the current document.
+	 *
+	 * @return void
+	 */
+	private function remove_unexported_rest_discovery_links( $xpath ) {
+		if ( $this->options->get( 'add_rest_api' ) ) {
+			return;
+		}
+
+		$links = $xpath->query( '//link[@rel]' );
+		if ( ! $links ) {
+			return;
+		}
+
+		$links_to_remove = array();
+		foreach ( $links as $link ) {
+			if ( $this->is_rest_discovery_link( $link ) ) {
+				$links_to_remove[] = $link;
+			}
+		}
+
+		foreach ( $links_to_remove as $link ) {
+			if ( $link->parentNode ) {
+				$link->parentNode->removeChild( $link );
+			}
+		}
+	}
+
+	/**
+	 * Determine whether a link element advertises a WordPress REST endpoint.
+	 *
+	 * @param \DOMElement $link Link element.
+	 *
+	 * @return bool
+	 */
+	private function is_rest_discovery_link( $link ) {
+		$rel_tokens = preg_split( '/\s+/', strtolower( trim( $link->getAttribute( 'rel' ) ) ) );
+		$rel_tokens = is_array( $rel_tokens ) ? array_filter( $rel_tokens ) : array();
+
+		if ( in_array( 'https://api.w.org/', $rel_tokens, true ) || in_array( 'https://api.w.org', $rel_tokens, true ) ) {
+			return true;
+		}
+
+		if ( ! in_array( 'alternate', $rel_tokens, true ) || ! $link->hasAttribute( 'href' ) ) {
+			return false;
+		}
+
+		$content_type = strtolower( trim( $link->getAttribute( 'type' ) ) );
+		if ( ! in_array( $content_type, array( 'application/json', 'application/json+oembed', 'text/xml+oembed' ), true ) ) {
+			return false;
+		}
+
+		return $this->is_wordpress_rest_url( $link->getAttribute( 'href' ) );
+	}
+
+	/**
+	 * Determine whether a URL resolves to a local WordPress REST route.
+	 *
+	 * @param string $href Link URL.
+	 *
+	 * @return bool
+	 */
+	private function is_wordpress_rest_url( $href ) {
+		$url = Util::relative_to_absolute_url( html_entity_decode( (string) $href, ENT_QUOTES | ENT_HTML5, 'UTF-8' ), $this->static_page->url );
+		if ( ! is_string( $url ) || '' === $url || ! Util::is_local_url( $url ) ) {
+			return false;
+		}
+
+		$parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url );
+		if ( ! is_array( $parts ) ) {
+			return false;
+		}
+
+		$path = isset( $parts['path'] ) ? (string) $parts['path'] : '';
+		if ( 1 === preg_match( '#(?:^|/)wp-json(?:/|$)#i', $path ) ) {
+			return true;
+		}
+
+		if ( empty( $parts['query'] ) ) {
+			return false;
+		}
+
+		$query_args = array();
+		parse_str( html_entity_decode( (string) $parts['query'], ENT_QUOTES | ENT_HTML5, 'UTF-8' ), $query_args );
+
+		return array_key_exists( 'rest_route', $query_args );
+	}
+
+	/**
 	 * Determine if a link element is a local resource hint that should not be
 	 * emitted in the static export.
 	 *
@@ -1290,6 +1381,8 @@ class Url_Extractor {
 		if ( ! $dom->documentElement ) {
 			return $html_string;
 		} else {
+			$this->remove_unexported_rest_discovery_links( $xpath );
+
 			// handle tags with attributes
 			foreach ( $match_tags as $tag_name => $attributes ) {
 				$elements = $xpath->query( '//' . $tag_name );

--- a/src/crawler/class-ss-crawler.php
+++ b/src/crawler/class-ss-crawler.php
@@ -129,6 +129,7 @@ abstract class Crawler {
 				$static_page = \Simply_Static\Page::query()->find_or_initialize_by( 'url', $url );
 				$static_page->set_status_message( sprintf( __( 'Added by %s Crawler', 'simply-static' ), $this->name ) );
 				$static_page->found_on_id = 0;
+				$this->configure_static_page( $static_page, $url );
 				$static_page->save();
 				$count++;
 			}
@@ -141,6 +142,17 @@ abstract class Crawler {
 		}
 
 		return $count;
+	}
+
+	/**
+	 * Allow a crawler to configure its Page record before it is queued.
+	 *
+	 * @param \Simply_Static\Page $static_page Page record being queued.
+	 * @param string               $url         Detected URL.
+	 *
+	 * @return void
+	 */
+	protected function configure_static_page( $static_page, $url ) {
 	}
 
 	/**

--- a/src/crawler/class-ss-sitemap-crawler.php
+++ b/src/crawler/class-ss-sitemap-crawler.php
@@ -327,14 +327,18 @@ class Sitemap_Crawler extends Crawler {
 	 * @return array
 	 */
 	private function extract_stylesheet_urls( $xml, $document_url ) : array {
-		$instructions = $xml->xpath( '/processing-instruction("xml-stylesheet")' );
-		if ( false === $instructions ) {
+		$root_node = dom_import_simplexml( $xml );
+		if ( false === $root_node || ! $root_node->ownerDocument ) {
 			return array();
 		}
 
 		$urls = array();
-		foreach ( $instructions as $instruction ) {
-			if ( 1 !== preg_match( '/(?:^|\s)href\s*=\s*(["\'])(.*?)\1/i', (string) $instruction, $matches ) ) {
+		foreach ( $root_node->ownerDocument->childNodes as $instruction ) {
+			if ( XML_PI_NODE !== $instruction->nodeType || 'xml-stylesheet' !== strtolower( $instruction->nodeName ) ) {
+				continue;
+			}
+
+			if ( 1 !== preg_match( '/(?:^|\s)href\s*=\s*(["\'])(.*?)\1/i', (string) $instruction->nodeValue, $matches ) ) {
 				continue;
 			}
 

--- a/src/crawler/class-ss-sitemap-crawler.php
+++ b/src/crawler/class-ss-sitemap-crawler.php
@@ -90,6 +90,16 @@ class Sitemap_Crawler extends Crawler {
 				continue;
 			}
 
+			foreach ( $this->extract_stylesheet_urls( $xml, $url ) as $stylesheet_url ) {
+				if ( count( $urls ) >= $max_urls ) {
+					break;
+				}
+
+				// Stylesheet processing instructions are untrusted sitemap input too.
+				// Only same-origin HTTP(S) resources may reach the fetch queue.
+				$this->add_unique_local_url( $urls, $stylesheet_url );
+			}
+
 			$root_name = strtolower( $xml->getName() );
 
 			if ( 'sitemapindex' === $root_name ) {
@@ -297,6 +307,41 @@ class Sitemap_Crawler extends Crawler {
 		foreach ( $locations as $location ) {
 			$url = trim( (string) $location );
 			if ( '' !== $url ) {
+				$urls[] = $url;
+			}
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * Extract stylesheet URLs from xml-stylesheet processing instructions.
+	 *
+	 * WordPress's native sitemap index and child sitemap documents reference
+	 * different XSL files. These resources are not represented by <loc> nodes,
+	 * so they need to be discovered from the processing instruction itself.
+	 *
+	 * @param \SimpleXMLElement $xml          Parsed sitemap XML.
+	 * @param string            $document_url URL of the sitemap document.
+	 *
+	 * @return array
+	 */
+	private function extract_stylesheet_urls( $xml, $document_url ) : array {
+		$instructions = $xml->xpath( '/processing-instruction("xml-stylesheet")' );
+		if ( false === $instructions ) {
+			return array();
+		}
+
+		$urls = array();
+		foreach ( $instructions as $instruction ) {
+			if ( 1 !== preg_match( '/(?:^|\s)href\s*=\s*(["\'])(.*?)\1/i', (string) $instruction, $matches ) ) {
+				continue;
+			}
+
+			$href = html_entity_decode( trim( $matches[2] ), ENT_QUOTES | ENT_XML1, 'UTF-8' );
+			$url  = \Simply_Static\Util::relative_to_absolute_url( $href, $document_url );
+
+			if ( is_string( $url ) && '' !== $url ) {
 				$urls[] = $url;
 			}
 		}

--- a/src/crawler/class-ss-text-file-crawler.php
+++ b/src/crawler/class-ss-text-file-crawler.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Simply_Static\Crawler;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Simply Static public text file crawler.
+ *
+ * Discovers conventional text endpoints which are normally not linked from an
+ * HTML page and may be generated dynamically rather than stored on disk.
+ */
+class Text_File_Crawler extends Crawler {
+
+	/**
+	 * Crawler ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'text_file';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->name        = __( 'Public Text Files', 'simply-static' );
+		$this->description = __( 'Detects conventional public text files such as llms.txt.', 'simply-static' );
+	}
+
+	/**
+	 * Detect public text file URLs.
+	 *
+	 * @return array List of live, local text file URLs.
+	 */
+	public function detect() : array {
+		if ( ! (bool) apply_filters( 'ss_include_llms_txt_in_export', true ) ) {
+			return array();
+		}
+
+		$llms_url = apply_filters( 'simply_static_llms_txt_url', home_url( '/llms.txt' ) );
+		if ( ! is_string( $llms_url ) || '' === trim( $llms_url ) || ! \Simply_Static\Util::is_local_origin_url( $llms_url ) ) {
+			return array();
+		}
+
+		return $this->is_live_text_endpoint( $llms_url ) ? array( $llms_url ) : array();
+	}
+
+	/**
+	 * Assign URL replacement support to discovered plain-text files.
+	 *
+	 * @param \Simply_Static\Page $static_page Page record being queued.
+	 * @param string               $url         Detected URL.
+	 *
+	 * @return void
+	 */
+	protected function configure_static_page( $static_page, $url ) {
+		$static_page->handler = \Simply_Static\Text_File_Handler::class;
+	}
+
+	/**
+	 * Probe a local text endpoint without downloading an unbounded response.
+	 *
+	 * @param string $url Endpoint URL.
+	 *
+	 * @return bool
+	 */
+	private function is_live_text_endpoint( $url ) : bool {
+		$timeout = (float) apply_filters( 'simply_static_text_file_request_timeout', 5.0 );
+		$timeout = max( 0.1, min( 30.0, $timeout ) );
+
+		$max_bytes = (int) apply_filters( 'simply_static_text_file_probe_size', 4096 );
+		$max_bytes = max( 1, min( 1024 * 1024, $max_bytes ) );
+
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout'             => $timeout,
+				'redirection'         => 0,
+				'sslverify'           => true,
+				'limit_response_size' => $max_bytes,
+			)
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( ! is_string( $body ) || '' === trim( $body ) ) {
+			return false;
+		}
+
+		// Avoid queueing a soft-404 HTML document as llms.txt.
+		$sample = ltrim( \Simply_Static\Util::strip_bom( $body ) );
+		$valid  = 1 !== preg_match( '/^(?:<!doctype\s+html\b|<html\b)/i', $sample );
+
+		return (bool) apply_filters( 'simply_static_text_file_probe_is_valid', $valid, $response, $url );
+	}
+}

--- a/tests/Unit/SitemapCrawlerTest.php
+++ b/tests/Unit/SitemapCrawlerTest.php
@@ -38,6 +38,7 @@ namespace Simply_Static\Tests\Unit {
 			parent::setUp();
 			$this->requireSource( 'src/class-ss-plugin.php' );
 			$this->requireSource( 'src/class-ss-options.php' );
+			$this->requireSource( 'src/class-ss-phpuri.php' );
 			$this->requireSource( 'src/class-ss-util.php' );
 			$this->requireSource( 'src/crawler/class-ss-crawler.php' );
 			$this->requireSource( 'src/crawler/class-ss-sitemap-crawler.php' );
@@ -97,6 +98,50 @@ namespace Simply_Static\Tests\Unit {
 
 			self::assertSame(
 				array( 'https://example.test/allowed/?q=one' ),
+				( new Sitemap_Crawler() )->detect()
+			);
+		}
+
+		public function test_it_discovers_the_native_sitemap_index_stylesheet(): void {
+			$this->setXmlResponse(
+				'<?xml version="1.0"?>'
+				. '<?xml-stylesheet type="text/xsl" href="/wp-sitemap-index.xsl"?>'
+				. '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>'
+			);
+
+			self::assertSame(
+				array( 'https://example.test/wp-sitemap-index.xsl' ),
+				( new Sitemap_Crawler() )->detect()
+			);
+		}
+
+		public function test_it_discovers_the_native_child_sitemap_stylesheet(): void {
+			$this->setXmlResponse(
+				'<?xml version="1.0"?>'
+				. '<?xml-stylesheet type="text/xsl" href="https://example.test/wp-sitemap.xsl"?>'
+				. '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+				. '<url><loc>https://example.test/page/</loc></url></urlset>'
+			);
+
+			self::assertSame(
+				array(
+					'https://example.test/wp-sitemap.xsl',
+					'https://example.test/page/',
+				),
+				( new Sitemap_Crawler() )->detect()
+			);
+		}
+
+		public function test_it_rejects_external_sitemap_stylesheets(): void {
+			$this->setXmlResponse(
+				'<?xml version="1.0"?>'
+				. '<?xml-stylesheet type="text/xsl" href="https://attacker.test/private.xsl"?>'
+				. '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+				. '<url><loc>https://example.test/page/</loc></url></urlset>'
+			);
+
+			self::assertSame(
+				array( 'https://example.test/page/' ),
 				( new Sitemap_Crawler() )->detect()
 			);
 		}

--- a/tests/Unit/TextFileCrawlerTest.php
+++ b/tests/Unit/TextFileCrawlerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use ReflectionMethod;
+use Simply_Static\Crawler\Text_File_Crawler;
+use Simply_Static\Tests\Support\UnitTestCase;
+use Simply_Static\Tests\Support\WpTestEnvironment as WpEnv;
+
+final class TextFileCrawlerTest extends UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->requireSource( 'src/class-ss-plugin.php' );
+		$this->requireSource( 'src/class-ss-options.php' );
+		$this->requireSource( 'src/class-ss-phpuri.php' );
+		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/crawler/class-ss-crawler.php' );
+		$this->requireSource( 'src/crawler/class-ss-text-file-crawler.php' );
+	}
+
+	public function test_it_discovers_a_live_dynamic_llms_file_with_a_bounded_request(): void {
+		$this->setResponse( 200, "# Example\n\n- [Docs](https://example.test/docs/)" );
+
+		self::assertSame(
+			array( 'https://example.test/llms.txt' ),
+			( new Text_File_Crawler() )->detect()
+		);
+
+		self::assertCount( 1, WpEnv::$remote_requests );
+		$request = WpEnv::$remote_requests[0];
+		self::assertSame( 'GET', $request['method'] );
+		self::assertSame( 'https://example.test/llms.txt', $request['url'] );
+		self::assertSame( 5.0, $request['args']['timeout'] );
+		self::assertSame( 0, $request['args']['redirection'] );
+		self::assertTrue( $request['args']['sslverify'] );
+		self::assertSame( 4096, $request['args']['limit_response_size'] );
+	}
+
+	/**
+	 * @dataProvider invalidResponseProvider
+	 */
+	public function test_it_does_not_queue_missing_empty_or_html_responses( int $status, string $body ): void {
+		$this->setResponse( $status, $body );
+
+		self::assertSame( array(), ( new Text_File_Crawler() )->detect() );
+	}
+
+	/** @return array<string,array{int,string}> */
+	public function invalidResponseProvider(): array {
+		return array(
+			'not found' => array( 404, 'Not found' ),
+			'empty'     => array( 200, '' ),
+			'soft 404'  => array( 200, '<!doctype html><html><body>Not found</body></html>' ),
+		);
+	}
+
+	public function test_it_respects_the_existing_llms_exclusion_filter_without_a_request(): void {
+		add_filter( 'ss_include_llms_txt_in_export', static function () {
+			return false;
+		} );
+
+		self::assertSame( array(), ( new Text_File_Crawler() )->detect() );
+		self::assertSame( array(), WpEnv::$remote_requests );
+	}
+
+	public function test_it_rejects_a_filtered_external_llms_endpoint_before_requesting_it(): void {
+		add_filter( 'simply_static_llms_txt_url', static function () {
+			return 'https://attacker.test/llms.txt';
+		} );
+
+		self::assertSame( array(), ( new Text_File_Crawler() )->detect() );
+		self::assertSame( array(), WpEnv::$remote_requests );
+	}
+
+	public function test_it_rejects_an_alternate_port_before_requesting_it(): void {
+		add_filter( 'simply_static_llms_txt_url', static function () {
+			return 'https://example.test:8443/llms.txt';
+		} );
+
+		self::assertSame( array(), ( new Text_File_Crawler() )->detect() );
+		self::assertSame( array(), WpEnv::$remote_requests );
+	}
+
+	public function test_it_assigns_the_text_file_handler_to_discovered_pages(): void {
+		$page   = new \stdClass();
+		$method = new ReflectionMethod( Text_File_Crawler::class, 'configure_static_page' );
+		$method->setAccessible( true );
+		$method->invoke( new Text_File_Crawler(), $page, 'https://example.test/llms.txt' );
+
+		self::assertSame( 'Simply_Static\\Text_File_Handler', $page->handler );
+	}
+
+	private function setResponse( int $status, string $body ): void {
+		WpEnv::$remote_response = array(
+			'response' => array( 'code' => $status ),
+			'headers'  => array(),
+			'body'     => $body,
+		);
+	}
+}

--- a/tests/Unit/UrlExtractorTest.php
+++ b/tests/Unit/UrlExtractorTest.php
@@ -97,6 +97,43 @@ final class UrlExtractorTest extends UnitTestCase {
 		}
 	}
 
+	public function test_removes_wordpress_rest_discovery_links_when_rest_api_is_not_exported(): void {
+		WpEnv::$options['simply-static']['add_rest_api'] = false;
+		Options::reinstance();
+
+		$html = '<html><head>'
+			. '<link href="https://example.test/wp-json/" rel="https://api.w.org/">'
+			. '<link title="REST JSON" href="https://example.test/?rest_route=/wp/v2/pages/7" type="application/json" rel="alternate">'
+			. '<link rel="alternate" type="application/json+oembed" href="https://example.test/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fexample.test%2Fblog%2Fpage">'
+			. '<link rel="alternate" type="text/xml+oembed" href="https://example.test/wp-json/oembed/1.0/embed?format=xml">'
+			. '<link title="Site feed" rel="alternate" type="application/json" href="https://example.test/feed.json">'
+			. '</head><body></body></html>';
+		$extractor = $this->extractor( 'html', $html );
+		$urls      = $extractor->extract_and_update_urls();
+		$body      = $extractor->get_body();
+
+		self::assertStringNotContainsString( 'api.w.org', $body );
+		self::assertStringNotContainsString( 'rest_route', $body );
+		self::assertStringNotContainsString( 'json+oembed', $body );
+		self::assertStringNotContainsString( 'xml+oembed', $body );
+		self::assertStringContainsString( 'title="Site feed"', $body );
+		self::assertNotContains( 'https://example.test/wp-json/', $urls );
+		self::assertContains( 'https://example.test/feed.json', $urls );
+	}
+
+	public function test_preserves_wordpress_rest_discovery_links_when_rest_api_is_exported(): void {
+		WpEnv::$options['simply-static']['add_rest_api'] = true;
+		Options::reinstance();
+
+		$html      = '<link rel="https://api.w.org/" href="https://example.test/wp-json/">';
+		$extractor = $this->extractor( 'html', $html );
+		$urls      = $extractor->extract_and_update_urls();
+
+		self::assertStringContainsString( 'rel="https://api.w.org/"', $extractor->get_body() );
+		self::assertStringContainsString( 'href="https://static.example.test/wp-json/"', $extractor->get_body() );
+		self::assertContains( 'https://example.test/wp-json/', $urls );
+	}
+
 	public function test_css_imports_and_urls_are_extracted_and_rewritten(): void {
 		$css = '@import url("../base.css"); .a{background:url(./image.png)} .b{src:url(https://external.test/font.woff2)}'
 			. ".c{background:url('../single.png')}";


### PR DESCRIPTION
## Summary

- Remove WordPress REST and oEmbed discovery links when REST API export is disabled, while preserving them when enabled.
- Discover and queue same-origin sitemap XSL resources and dynamic `/llms.txt` files, assigning text-file handling before queueing.
- Add unit coverage for REST discovery behavior, sitemap stylesheets, and text-file endpoint validation.

## Testing

`./vendor/bin/phpunit --configuration phpunit.xml.dist tests/Unit/UrlExtractorTest.php tests/Unit/SitemapCrawlerTest.php tests/Unit/TextFileCrawlerTest.php` (19 tests, 58 assertions)