### PR TITLE
Prepare release 3.8.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jamstack, performance, security, static site generator
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag:  3.8.3
+Stable tag:  3.8.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -274,6 +274,16 @@ Settings - Configure your static site export options
 Diagnostics - Check your WordPress environment for compatibility
 
 == Changelog ==
+
+= 3.8.4 =
+
+* Added export discovery for public llms.txt files and sitemap stylesheets
+* Removed WordPress REST discovery links when REST routes are not included in exports
+* Prevented internal export page IDs from leaking into generated current URLs
+* Fixed asset export paths for WordPress installations in subdirectories
+* Normalized transfer path separators across platforms
+* Fixed CSS URL parsing for SVG data URIs, including large stylesheets
+* Restored admin compatibility with WordPress 6.2
 
 = 3.8.3 =
 

--- a/simply-static.php
+++ b/simply-static.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Simply Static
  * Plugin URI:        https://simplystatic.com
  * Description:       A static site generator to create fast and secure static versions of your WordPress website.
- * Version:           3.8.3
+ * Version:           3.8.4
  * Requires at least:  6.2
  * Author:            Patrick Posner
  * Author URI:        https://patrickposner.com
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'SIMPLY_STATIC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLY_STATIC_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'SIMPLY_STATIC_VERSION', '3.8.3' );
+define( 'SIMPLY_STATIC_VERSION', '3.8.4' );
 
 // Check PHP version.
 if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {

--- a/src/admin/package-lock.json
+++ b/src/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplystatic-settings",
-      "version": "3.8.3",
+      "version": "3.8.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "react-data-table-component": "^8.5.0",

--- a/src/admin/package.json
+++ b/src/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/tests/Unit/BootstrapCompatibilityTest.php
+++ b/tests/Unit/BootstrapCompatibilityTest.php
@@ -54,6 +54,7 @@ namespace Simply_Static\Tests\Unit {
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.1' ) );
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.2' ) );
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.3' ) );
+			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.4' ) );
 		}
 
 		public function test_outdated_active_pro_is_left_active_but_all_runtime_hooks_are_blocked(): void {
@@ -101,20 +102,20 @@ namespace Simply_Static\Tests\Unit {
 			$package   = json_decode( (string) file_get_contents( $root . '/src/admin/package.json' ), true );
 			$lock      = json_decode( (string) file_get_contents( $root . '/src/admin/package-lock.json' ), true );
 
-			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.3$/m', $bootstrap );
+			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.4$/m', $bootstrap );
 			self::assertMatchesRegularExpression( '/^ \* Requires at least:\s+6\.2$/m', $bootstrap );
-			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.3' );", $bootstrap );
+			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.4' );", $bootstrap );
 			self::assertStringContainsString( "version_compare( get_bloginfo( 'version' ), '6.2', '<' )", $bootstrap );
 			self::assertStringContainsString( 'Simply Static requires WordPress 6.2 or higher.', $bootstrap );
 			self::assertStringContainsString( "require_once SIMPLY_STATIC_PATH . 'src/class-ss-pro-compatibility.php';", $bootstrap );
 			self::assertStringContainsString( "add_action( 'plugins_loaded', array( 'Simply_Static\\Pro_Compatibility', 'enforce' ), 1 );", $bootstrap );
 			self::assertStringNotContainsString( 'deactivate_plugins( $pro_basename', $bootstrap );
-			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.3$/m', $readme );
+			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.4$/m', $readme );
 			self::assertMatchesRegularExpression( '/^Requires at least:\s+6\.2$/m', $readme );
-			self::assertStringContainsString( '= 3.8.3 =', $readme );
-			self::assertSame( '3.8.3', $package['version'] ?? null );
-			self::assertSame( '3.8.3', $lock['version'] ?? null );
-			self::assertSame( '3.8.3', $lock['packages']['']['version'] ?? null );
+			self::assertStringContainsString( '= 3.8.4 =', $readme );
+			self::assertSame( '3.8.4', $package['version'] ?? null );
+			self::assertSame( '3.8.4', $lock['version'] ?? null );
+			self::assertSame( '3.8.4', $lock['packages']['']['version'] ?? null );
 		}
 
 		private function registerProRuntimeHooks(): void {


### PR DESCRIPTION
Updates the plugin, admin package, lockfile, and release assertions to version 3.8.4. Adds the 3.8.4 changelog covering resource discovery, REST link cleanup, export URL noise, subdirectory paths, cross-platform transfers, CSS SVG parsing, and WordPress 6.2 compatibility. Verified with 336 PHP tests, 51 admin tests, JavaScript lint, and a production build with no generated asset changes.