### PR TITLE
Skip SHOW GRANTS rows without an ON clause in Sql_Permissions

### DIFF
--- a/src/class-ss-sql-permissions.php
+++ b/src/class-ss-sql-permissions.php
@@ -65,8 +65,11 @@ class Sql_Permissions {
 			// Loop through all of the grants and set permissions to true where
 			// we're able to find them.
 			foreach ( $rows as $row ) {
-				// Find the database name
-				preg_match( '/GRANT (.+) ON (.+) TO/', $row[0], $matches );
+				// Find the database name. Skip rows without an ON clause, e.g.
+				// MySQL 8 role grants like "GRANT `role`@`%` TO `user`@`%`".
+				if ( ! preg_match( '/GRANT (.+) ON (.+) TO/', $row[0], $matches ) ) {
+					continue;
+				}
 				// Removing backticks and backslashes for easier matching
 				$db_name = preg_replace('/[\\\`]/', '', $matches[2]);
 


### PR DESCRIPTION
`Sql_Permissions::instance()` parses each `SHOW GRANTS FOR current_user()` row with `/GRANT (.+) ON (.+) TO/` but never checks whether the pattern matched before reading `$matches[2]` (and `$matches[1]` further down). On MySQL 8 a role grant such as `GRANT ` + "`role`@`%`" + ` TO ` + "`user`@`%`" has no `ON` clause, so the regex fails, `$matches` stays empty, and the loop emits `Undefined array key` warnings. This skips those rows, which carry no database/permission grant anyway, matching the guard suggested in #410.

I couldn't add a unit test here because `instance()` reads through the `global $wpdb` singleton and the class caches a `protected static $instance`, so there's no existing harness to feed synthetic grant rows through. The change mirrors the maintainer-suggested fix exactly. Fixes #410.
