### PR TITLE
Skip role-grant rows without an ON clause in SQL permission check

### DIFF
--- a/src/class-ss-sql-permissions.php
+++ b/src/class-ss-sql-permissions.php
@@ -66,7 +66,11 @@ class Sql_Permissions {
 			// we're able to find them.
 			foreach ( $rows as $row ) {
 				// Find the database name
-				preg_match( '/GRANT (.+) ON (.+) TO/', $row[0], $matches );
+				if ( ! preg_match( '/GRANT (.+) ON (.+) TO/', $row[0], $matches ) ) {
+					// Skip rows without an ON clause, e.g. MySQL 8 role grants:
+					// GRANT `role`@`%` TO `user`@`%`
+					continue;
+				}
 				// Removing backticks and backslashes for easier matching
 				$db_name = preg_replace('/[\\\`]/', '', $matches[2]);
 


### PR DESCRIPTION
## Summary

Fixes #410.

`Sql_Permissions::instance()` runs every `SHOW GRANTS FOR current_user()` row through `preg_match( '/GRANT (.+) ON (.+) TO/', ... )` without checking the result. On MySQL 8 a role grant like `GRANT \`role\`@\`%\` TO \`user\`@\`%\`` has no `ON` clause, so the pattern does not match, `$matches` stays empty, and `$matches[2]` (and later `$matches[1]`) triggers `Undefined array key` warnings on every Diagnostics run. Amazon Aurora MySQL 8 hits this out of the box because the master user is granted `rds_superuser_role` this way.

This skips rows the pattern does not match so only real `GRANT ... ON ... TO` rows are parsed. Matching rows are unaffected, so the permission detection is unchanged.

Reproducing the warning needs a MySQL 8 instance with a role grant on the current user, which I could not stand up locally, so this change is not covered by a new test.
