### PR TITLE
Skip deprecated wp-includes asset placeholders

### DIFF
--- a/src/crawler/class-ss-wp-includes-crawler.php
+++ b/src/crawler/class-ss-wp-includes-crawler.php
@@ -88,6 +88,8 @@ class Wp_Includes_Crawler extends Crawler {
 			$it = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $full_path, \RecursiveDirectoryIterator::SKIP_DOTS ) );
 			foreach ( $it as $file ) {
 				if ( $file->isDir() ) continue;
+				// WordPress keeps removed core assets as empty placeholders for some releases.
+				if ( 0 === $file->getSize() ) continue;
 				$rel = \Simply_Static\Util::safe_relative_path( $full_path, $file->getPathname() );
 				if ( in_array( strtolower( pathinfo( $rel, PATHINFO_EXTENSION ) ), $exts, true ) ) {
 					$urls[] = \Simply_Static\Util::safe_join_url( $dir_url, $rel );

--- a/tests/Unit/WpIncludesCrawlerTest.php
+++ b/tests/Unit/WpIncludesCrawlerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use Simply_Static\Crawler\Wp_Includes_Crawler;
+use Simply_Static\Tests\Support\UnitTestCase;
+
+final class WpIncludesCrawlerTest extends UnitTestCase {
+
+	/** @var string */
+	private $includes_dir;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->requireSource( 'src/class-ss-plugin.php' );
+		$this->requireSource( 'src/class-ss-options.php' );
+		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/crawler/class-ss-crawler.php' );
+		$this->requireSource( 'src/crawler/class-ss-wp-includes-crawler.php' );
+
+		$this->includes_dir = ABSPATH . 'wp-includes/js/';
+		wp_mkdir_p( $this->includes_dir . 'swfupload' );
+	}
+
+	protected function tearDown(): void {
+		foreach (
+			array(
+				'supported.js',
+				'swfobject.js',
+				'swfupload/handlers.js',
+				'swfupload/handlers.min.js',
+				'swfupload/swfupload.js',
+			) as $file
+		) {
+			@unlink( $this->includes_dir . $file );
+		}
+
+		@rmdir( $this->includes_dir . 'swfupload' );
+		@rmdir( $this->includes_dir );
+		@rmdir( dirname( $this->includes_dir ) );
+		@rmdir( ABSPATH );
+
+		parent::tearDown();
+	}
+
+	public function test_detect_skips_empty_deprecated_assets(): void {
+		file_put_contents( $this->includes_dir . 'supported.js', 'window.supported = true;' );
+		file_put_contents( $this->includes_dir . 'swfobject.js', '' );
+		file_put_contents( $this->includes_dir . 'swfupload/handlers.js', '' );
+		file_put_contents( $this->includes_dir . 'swfupload/handlers.min.js', '' );
+		file_put_contents( $this->includes_dir . 'swfupload/swfupload.js', '' );
+
+		$urls = ( new Wp_Includes_Crawler() )->detect();
+
+		self::assertContains( 'https://example.test/wp-includes/js/supported.js', $urls );
+		self::assertNotContains( 'https://example.test/wp-includes/js/swfobject.js', $urls );
+		self::assertNotContains( 'https://example.test/wp-includes/js/swfupload/handlers.js', $urls );
+		self::assertNotContains( 'https://example.test/wp-includes/js/swfupload/handlers.min.js', $urls );
+		self::assertNotContains( 'https://example.test/wp-includes/js/swfupload/swfupload.js', $urls );
+	}
+
+	public function test_detect_keeps_non_empty_legacy_assets(): void {
+		file_put_contents( $this->includes_dir . 'swfobject.js', 'window.swfobject = {};' );
+
+		$urls = ( new Wp_Includes_Crawler() )->detect();
+
+		self::assertContains( 'https://example.test/wp-includes/js/swfobject.js', $urls );
+	}
+}


### PR DESCRIPTION
## Summary

- Skip zero-byte assets when crawling wp-includes so deprecated placeholders are not exported.
- Preserve non-empty legacy assets for older WordPress installations.
- Add regression tests covering removed SWF assets and compatibility behavior.

## Testing

- `vendor/bin/phpunit --configuration phpunit.xml.dist` (338 tests, 4,474 assertions)