### PR TITLE
Requeue assets when generated paths change

### DIFF
--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -403,16 +403,17 @@ class Url_Fetcher {
 	}
 
 	/**
-	 * Given a Static_Page, return a relative filename based on the URL
+	 * Build the unfiltered relative filename for a static page.
 	 *
-	 * This will also create directories as needed so that a file could be
-	 * created at the returned file path.
+	 * This calculation intentionally has no filesystem side effects so callers
+	 * can compare a stored path with the path the current export rules would
+	 * generate.
 	 *
-	 * @param \Simply_Static\Page $static_page The Simply_Static\Page
+	 * @param \Simply_Static\Page $static_page The Simply_Static\Page.
 	 *
-	 * @return string|null                The relative file path of the file
+	 * @return string|null The relative file path, or null when no file should be created.
 	 */
-	public function create_directories_for_static_page( $static_page ) {
+	private function build_relative_filename_for_static_page( $static_page ) {
 		$url_parts = parse_url( $static_page->url );
 		// a domain with no trailing slash has no path, so we're giving it one
 		$path = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
@@ -505,12 +506,50 @@ class Url_Fetcher {
 		$sanitized_relative_dir = Util::sanitize_path( (string) urldecode( $relative_file_dir ) );
 		$sanitized_filename     = Util::sanitize_filename( (string) $path_info['filename'] );
 
-		$create_dir = wp_mkdir_p( $this->archive_dir . $sanitized_relative_dir );
+		return $sanitized_relative_dir . $sanitized_filename . ( $path_info['extension'] ? '.' . $path_info['extension'] : '' );
+	}
+
+	/**
+	 * Return the final relative filename produced by the current export rules.
+	 *
+	 * @param \Simply_Static\Page $static_page The Simply_Static\Page.
+	 *
+	 * @return string|null The filtered relative file path.
+	 */
+	public function get_expected_file_path_for_static_page( $static_page ) {
+		$relative_filename = $this->build_relative_filename_for_static_page( $static_page );
+
+		if ( null === $relative_filename ) {
+			return null;
+		}
+
+		return apply_filters( 'simply_static_relative_filename', $relative_filename, $static_page );
+	}
+
+	/**
+	 * Given a Static_Page, return a relative filename based on the URL.
+	 *
+	 * This will also create directories as needed so that a file could be
+	 * created at the returned file path.
+	 *
+	 * @param \Simply_Static\Page $static_page The Simply_Static\Page.
+	 *
+	 * @return string|null The unfiltered relative file path.
+	 */
+	public function create_directories_for_static_page( $static_page ) {
+		$relative_filename = $this->build_relative_filename_for_static_page( $static_page );
+		if ( null === $relative_filename ) {
+			return null;
+		}
+
+		$path_info         = Util::url_path_info( $relative_filename );
+		$relative_file_dir = $path_info['dirname'];
+		$create_dir        = wp_mkdir_p( $this->archive_dir . $relative_file_dir );
+
 		if ( $create_dir === false ) {
-			Util::debug_log( "Unable to create temporary directory: " . $this->archive_dir . $sanitized_relative_dir );
+			Util::debug_log( "Unable to create temporary directory: " . $this->archive_dir . $relative_file_dir );
 			$static_page->set_error_message( 'Unable to create temporary directory' );
 		} else {
-			$relative_filename = $sanitized_relative_dir . $sanitized_filename . ( $path_info['extension'] ? '.' . $path_info['extension'] : '' );
 			Util::debug_log( "New filename for static page: " . $relative_filename );
 
 			// check that file doesn't exist OR exists but is writeable

--- a/src/tasks/class-ss-fetch-urls-task.php
+++ b/src/tasks/class-ss-fetch-urls-task.php
@@ -693,6 +693,7 @@ class Fetch_Urls_Task extends Task {
 		}
 
 		$child_static_page = Page::query()->find_or_create_by( 'url', $child_url );
+		$path_migration    = $this->maybe_requeue_asset_for_path_migration( $child_static_page );
 
 		// During single exports, ensure discovered assets inherit the parent's
 		// post_id so they pass the post_id filter in get_pages_to_process_sql().
@@ -718,7 +719,60 @@ class Fetch_Urls_Task extends Task {
 			do_action( 'simply_static_child_page_found_on_url_before_save', $child_static_page, $static_page );
 
 			$child_static_page->save();
+		} elseif ( $path_migration ) {
+			$child_static_page->save();
 		}
+	}
+
+	/**
+	 * Requeue an existing local asset when its generated output path changed.
+	 *
+	 * Filename sanitization and path filters can change between plugin versions.
+	 * An update export may otherwise rewrite a changed page to the new asset path
+	 * while treating the existing asset record as unchanged and omitting the
+	 * corresponding file from the delta.
+	 *
+	 * @param \Simply_Static\Page $static_page Existing child asset record.
+	 *
+	 * @return bool Whether the asset was marked for refetch and transfer.
+	 */
+	protected function maybe_requeue_asset_for_path_migration( $static_page ) {
+		if ( 'update' !== $this->get_generate_type() ) {
+			return false;
+		}
+
+		if (
+			empty( $static_page->url )
+			|| empty( $static_page->file_path )
+			|| ! Util::is_local_asset_url( $static_page->url )
+		) {
+			return false;
+		}
+
+		$expected_file_path = Url_Fetcher::instance()->get_expected_file_path_for_static_page( $static_page );
+		if ( ! is_string( $expected_file_path ) || '' === $expected_file_path ) {
+			return false;
+		}
+
+		$stored_file_path   = ltrim( Util::normalize_slashes( (string) $static_page->file_path ), '/' );
+		$expected_file_path = ltrim( Util::normalize_slashes( $expected_file_path ), '/' );
+
+		if ( $stored_file_path === $expected_file_path ) {
+			return false;
+		}
+
+		$static_page->last_modified_at = Util::formatted_datetime();
+
+		Util::debug_log(
+			sprintf(
+				'Requeueing asset because its generated path changed from "%s" to "%s": %s',
+				$stored_file_path,
+				$expected_file_path,
+				$static_page->url
+			)
+		);
+
+		return true;
 	}
 
 	/**

--- a/tests/Support/wordpress-stubs.php
+++ b/tests/Support/wordpress-stubs.php
@@ -387,10 +387,13 @@ function sanitize_title( $title ) {
 }
 
 function sanitize_file_name( $filename ) {
+	$filename_raw = (string) $filename;
 	$filename = basename( str_replace( '\\', '/', (string) $filename ) );
 	$filename = preg_replace( '/[^A-Za-z0-9._-]+/u', '-', $filename );
 	$filename = preg_replace( '/\.{2,}/', '.', (string) $filename );
-	return trim( (string) $filename, '.-' );
+	$filename = trim( (string) $filename, '.-' );
+
+	return apply_filters( 'sanitize_file_name', $filename, $filename_raw );
 }
 
 function remove_accents( $text ) {
@@ -605,6 +608,10 @@ function remove_query_arg( $key, $url ) {
 
 function get_current_blog_id() {
 	return WpEnv::$current_blog_id;
+}
+
+function url_to_postid( $url ) {
+	return 0;
 }
 
 function get_blog_details( $fields = null, $get_all = true ) {

--- a/tests/Unit/FetchUrlsAssetPathMigrationTest.php
+++ b/tests/Unit/FetchUrlsAssetPathMigrationTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use Simply_Static\Fetch_Urls_Task;
+use Simply_Static\Options;
+use Simply_Static\Page;
+use Simply_Static\Page_Handler;
+use Simply_Static\Tests\Support\UnitTestCase;
+use Simply_Static\Tests\Support\WpTestEnvironment as WpEnv;
+
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-plugin.php';
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-options.php';
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-phpuri.php';
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-util.php';
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-query.php';
+require_once dirname( __DIR__, 2 ) . '/src/models/class-ss-model.php';
+require_once dirname( __DIR__, 2 ) . '/src/models/class-ss-page.php';
+require_once dirname( __DIR__, 2 ) . '/src/handlers/class-ss-page-handler.php';
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-url-fetcher.php';
+require_once dirname( __DIR__, 2 ) . '/src/tasks/class-ss-task.php';
+require_once dirname( __DIR__, 2 ) . '/src/tasks/traits/class-ss-skip-further-processing-exception.php';
+require_once dirname( __DIR__, 2 ) . '/src/tasks/traits/trait-ss-can-process-pages.php';
+require_once dirname( __DIR__, 2 ) . '/src/tasks/class-ss-fetch-urls-task.php';
+
+final class FetchUrlsAssetPathMigrationWpdb {
+
+	/** @var array<string,mixed> */
+	public $row = array();
+
+	/** @var array<int,array<string,mixed>> */
+	public $updates = array();
+
+	public function get_blog_prefix(): string {
+		return 'wp_';
+	}
+
+	/**
+	 * @param string $query
+	 * @param mixed  $output
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function get_row( $query, $output = null ): array {
+		return $this->row;
+	}
+
+	/**
+	 * @param array<string,mixed> $data
+	 * @param array<string,mixed> $where
+	 */
+	public function update( string $table, array $data, array $where ): int {
+		$this->updates[] = array(
+			'table' => $table,
+			'data'  => $data,
+			'where' => $where,
+		);
+		$this->row = array_merge( $this->row, $data );
+
+		return 1;
+	}
+}
+
+final class FetchUrlsAssetPathMigrationTest extends UnitTestCase {
+
+	private const ASSET_URL = 'https://example.test/wordpress/wp-content/uploads/2022/05/top-menu-04@2x.png';
+	private const HASHED_PATH = 'wordpress/wp-content/uploads/2022/05/933db1a4d7081b14748e63e95353a2a4.png';
+	private const LEGACY_PATH = 'wordpress/wp-content/uploads/2022/05/top-menu-04@2x.png';
+
+	/** @var FetchUrlsAssetPathMigrationWpdb */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->wpdb       = new FetchUrlsAssetPathMigrationWpdb();
+		$GLOBALS['wpdb'] = $this->wpdb;
+
+		WpEnv::$home_url = 'https://example.test';
+		WpEnv::$site_url = 'https://example.test/wordpress';
+		WpEnv::$options['simply-static'] = array(
+			'archive_start_time' => '2026-07-12 11:00:00',
+			'generate_type'      => 'update',
+			'origin_url'         => '',
+		);
+		Options::reinstance();
+
+		// Match WP Multibyte Patch's behavior for filenames that require URL encoding.
+		add_filter(
+			'sanitize_file_name',
+			static function ( string $sanitized, string $raw ): string {
+				return $raw === rawurlencode( $raw ) ? $sanitized : md5( $raw );
+			},
+			10,
+			2
+		);
+	}
+
+	public function test_update_requeues_existing_asset_when_sanitized_path_changed(): void {
+		$this->wpdb->row = $this->childRow( self::LEGACY_PATH );
+
+		( new Fetch_Urls_Task() )->set_url_found_on( $this->parentPage(), self::ASSET_URL );
+
+		self::assertCount( 1, $this->wpdb->updates );
+		self::assertSame(
+			array(
+				'last_modified_at' => '2026-07-12 12:00:00',
+			),
+			$this->wpdb->updates[0]['data']
+		);
+		self::assertSame( array( 'id' => 42 ), $this->wpdb->updates[0]['where'] );
+	}
+
+	public function test_update_does_not_requeue_asset_when_stored_path_is_current(): void {
+		$this->wpdb->row = $this->childRow( self::HASHED_PATH );
+
+		( new Fetch_Urls_Task() )->set_url_found_on( $this->parentPage(), self::ASSET_URL );
+
+		self::assertSame( array(), $this->wpdb->updates );
+	}
+
+	/** @return array<string,mixed> */
+	private function childRow( string $file_path ): array {
+		return array(
+			'id'                  => 42,
+			'site_id'             => 1,
+			'url'                 => self::ASSET_URL,
+			'file_path'           => $file_path,
+			'http_status_code'    => 200,
+			'content_type'        => 'image/png',
+			'handler'             => Page_Handler::class,
+			'found_on_id'         => 7,
+			'fetch_attempts'      => 0,
+			'last_checked_at'     => '2026-01-10 08:00:00',
+			'last_modified_at'    => '2026-01-10 08:00:00',
+			'last_transferred_at' => '2026-01-10 08:00:00',
+			'created_at'          => '2026-01-10 08:00:00',
+			'updated_at'          => '2026-07-12 12:00:00',
+		);
+	}
+
+	private function parentPage(): Page {
+		return Page::initialize(
+			array(
+				'id'      => 7,
+				'site_id' => 1,
+				'url'     => 'https://example.test/',
+			)
+		);
+	}
+}


### PR DESCRIPTION
Update exports now compare stored local asset paths with paths generated by the current filename sanitization and filters, requeueing assets when they differ. The URL fetcher exposes a side-effect-free expected-path calculation while preserving directory creation behavior. WordPress test stubs now support filename filters and `url_to_postid()`, with regression coverage for legacy and current paths.

Tests: `./vendor/bin/phpunit --configuration phpunit.xml.dist` (340 tests, 4478 assertions).