### PR TITLE
Simplify SSL verification for local origins

### DIFF
--- a/src/admin/inc/class-ss-admin-rest.php
+++ b/src/admin/inc/class-ss-admin-rest.php
@@ -1405,13 +1405,15 @@ class Admin_Rest {
 			// Clear only this process's healthcheck, never recurring export schedules.
 			wp_clear_scheduled_hook( $identifier . '_cron' );
 
-			// Clear the lock owned by this site without disturbing another site's
-			// process in multisite.
-			$lock_key = $identifier . '_process_lock';
-			if ( is_multisite() && null !== $site_id ) {
-				delete_site_transient( $lock_key . '_site_' . $site_id );
-			} else {
-				delete_site_transient( $lock_key );
+			// Clear this site's lock and cached loopback capability without
+			// disturbing another site's process in multisite.
+			foreach ( array( '_process_lock', '_loopback_available' ) as $transient_suffix ) {
+				$transient_key = $identifier . $transient_suffix;
+				if ( is_multisite() && null !== $site_id ) {
+					$transient_key .= '_site_' . $site_id;
+				}
+
+				delete_site_transient( $transient_key );
 			}
 
 			$options = method_exists( $job, 'get_options' ) ? $job->get_options() : Options::instance();

--- a/src/background/class-ss-async-request.php
+++ b/src/background/class-ss-async-request.php
@@ -156,13 +156,16 @@ abstract class Async_Request {
 		if ( property_exists( $this, 'post_args' ) ) {
 			$args = is_array( $this->post_args ) ? $this->post_args : array();
 		} else {
+			$url       = $this->get_query_url();
+			$sslverify = class_exists( __NAMESPACE__ . '\\Util' ) ? Util::should_verify_ssl( $url ) : true;
+			$sslverify = (bool) apply_filters( 'ss_remote_get_sslverify', $sslverify, $url );
 			$args = array(
 				'timeout'     => 5,
 				'blocking'    => false,
 				'redirection' => 0,
 				'body'        => is_array( $this->data ) ? $this->data : array(),
 				'cookies'     => $this->get_auth_cookies(),
-				'sslverify'   => (bool) apply_filters( 'https_local_ssl_verify', true ),
+				'sslverify'   => (bool) apply_filters( 'https_local_ssl_verify', $sslverify, $url ),
 			);
 		}
 

--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -171,10 +171,10 @@ class Url_Fetcher {
 					// Attempt 2: Do a non-streamed request and write body manually.
 					if ( ! $recovered ) {
 						$alt_url  = isset( $is_local_asset ) && $is_local_asset ? Util::get_source_url_from_local_url( $url ) : $url;
-						$alt_args          = array(
+						$alt_args = array(
 							'timeout'     => self::TIMEOUT,
 							'user-agent'  => apply_filters( 'ss_crawler_user_agent', self::DEFAULT_USER_AGENT ),
-							'sslverify'   => (bool) apply_filters( 'ss_remote_get_sslverify', true, $alt_url ),
+							'sslverify'   => (bool) apply_filters( 'ss_remote_get_sslverify', Util::should_verify_ssl( $alt_url ), $alt_url ),
 							'redirection' => 0,
 							'blocking'    => true,
 							'decompress'  => true,
@@ -547,7 +547,7 @@ class Url_Fetcher {
 		$args = array(
 			'timeout'     => self::TIMEOUT,
 			'user-agent'  => $user_agent,
-			'sslverify'   => (bool) apply_filters( 'ss_remote_get_sslverify', true, $url ),
+			'sslverify'   => (bool) apply_filters( 'ss_remote_get_sslverify', Util::should_verify_ssl( $url ), $url ),
 			'redirection' => 0, // disable redirection.
 			'blocking'    => true,
 			'decompress'  => true, // ensure WordPress decompresses gzip/deflate responses.

--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -1825,6 +1825,49 @@ class Util {
 	}
 
 	/**
+	 * Determine whether an internal request should verify its TLS certificate.
+	 *
+	 * Verification remains enabled unless the request targets an exact WordPress
+	 * origin in a local environment. Reserved local hostnames are detected
+	 * automatically so tools such as Herd work without configuration.
+	 *
+	 * @param string $url Request URL.
+	 *
+	 * @return bool
+	 */
+	public static function should_verify_ssl( $url ) {
+		$verify          = true;
+		$is_local_origin = false;
+
+		foreach ( self::local_url_bases() as $base ) {
+			if ( self::is_same_origin_url( $url, $base ) ) {
+				$is_local_origin = true;
+				break;
+			}
+		}
+
+		if ( $is_local_origin ) {
+			$url_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url );
+			$host      = is_array( $url_parts ) && isset( $url_parts['host'] )
+				? trim( self::normalize_url_host( $url_parts['host'] ), '[]' )
+				: '';
+			$is_local_environment = function_exists( 'wp_get_environment_type' )
+				&& 'local' === wp_get_environment_type();
+			$is_local_hostname = 'localhost' === $host
+				|| '::1' === $host
+				|| '127.0.0.1' === $host
+				|| '.test' === substr( $host, -5 )
+				|| '.localhost' === substr( $host, -10 );
+
+			if ( $is_local_environment || $is_local_hostname ) {
+				$verify = false;
+			}
+		}
+
+		return $verify;
+	}
+
+	/**
 	 * Return an HTTP Basic Authorization header only for an exact WordPress origin.
 	 *
 	 * @param string $url Request URL.

--- a/src/crawler/class-ss-pagination-crawler.php
+++ b/src/crawler/class-ss-pagination-crawler.php
@@ -443,7 +443,7 @@ class Pagination_Crawler extends Crawler {
 			$args = [
 				'timeout'             => min( $request_timeout, max( 1, $deadline - microtime( true ) ) ),
 				'redirection'         => 0,
-				'sslverify'           => (bool) apply_filters( 'ss_remote_get_sslverify', true, $current_url ),
+				'sslverify'           => (bool) apply_filters( 'ss_remote_get_sslverify', \Simply_Static\Util::should_verify_ssl( $current_url ), $current_url ),
 				'limit_response_size' => $max_body_bytes + 1,
 			];
 			$authorization = \Simply_Static\Util::get_basic_auth_header_for_url( $current_url );

--- a/src/crawler/class-ss-sitemap-crawler.php
+++ b/src/crawler/class-ss-sitemap-crawler.php
@@ -181,7 +181,7 @@ class Sitemap_Crawler extends Crawler {
 				array(
 					'timeout'     => min( $request_timeout, max( 0.1, $deadline - $this->now() ) ),
 					'redirection' => 0,
-					'sslverify'   => true,
+					'sslverify'   => (bool) apply_filters( 'ss_remote_get_sslverify', \Simply_Static\Util::should_verify_ssl( $sitemap_url ), $sitemap_url ),
 				)
 			);
 
@@ -234,7 +234,7 @@ class Sitemap_Crawler extends Crawler {
 			array(
 				'timeout'             => $request_timeout,
 				'redirection'         => 0,
-				'sslverify'           => true,
+				'sslverify'           => (bool) apply_filters( 'ss_remote_get_sslverify', \Simply_Static\Util::should_verify_ssl( $sitemap_url ), $sitemap_url ),
 				'limit_response_size' => $response_limit,
 			)
 		);

--- a/src/crawler/class-ss-text-file-crawler.php
+++ b/src/crawler/class-ss-text-file-crawler.php
@@ -79,7 +79,7 @@ class Text_File_Crawler extends Crawler {
 			array(
 				'timeout'             => $timeout,
 				'redirection'         => 0,
-				'sslverify'           => true,
+				'sslverify'           => (bool) apply_filters( 'ss_remote_get_sslverify', \Simply_Static\Util::should_verify_ssl( $url ), $url ),
 				'limit_response_size' => $max_bytes,
 			)
 		);

--- a/src/integrations/class-ss-integration.php
+++ b/src/integrations/class-ss-integration.php
@@ -163,10 +163,9 @@ abstract class Integration {
 			return new \WP_Error( 'ss_disallowed_remote_url', __( 'Integration requests must target the configured WordPress origin.', 'simply-static' ) );
 		}
 
-		// Verify TLS by default. Self-signed local environments can opt out for
-		// their exact origin with the narrowly scoped filter.
+		// Verify TLS by default, except for exact-origin local environments.
 		if ( ! isset( $args['sslverify'] ) ) {
-			$args['sslverify'] = (bool) apply_filters( 'ss_remote_get_sslverify', true, $url );
+			$args['sslverify'] = (bool) apply_filters( 'ss_remote_get_sslverify', Util::should_verify_ssl( $url ), $url );
 		}
 		// Redirects can cross origins while retaining request headers in some
 		// transports. Callers can explicitly opt in when no credentials are used.

--- a/tests/Support/WpTestEnvironment.php
+++ b/tests/Support/WpTestEnvironment.php
@@ -79,6 +79,9 @@ final class WpTestEnvironment {
 	/** @var string */
 	public static $site_url = 'https://example.test';
 
+	/** @var string */
+	public static $environment_type = 'production';
+
 	/** @var array<string,mixed> */
 	public static $upload_dir = array();
 
@@ -113,6 +116,7 @@ final class WpTestEnvironment {
 		self::$multisite        = false;
 		self::$home_url         = 'https://example.test';
 		self::$site_url         = 'https://example.test';
+		self::$environment_type = 'production';
 		self::$upload_dir       = array(
 			'basedir' => sys_get_temp_dir() . '/simply-static-tests/uploads',
 			'baseurl' => 'https://example.test/wp-content/uploads',

--- a/tests/Support/wordpress-stubs.php
+++ b/tests/Support/wordpress-stubs.php
@@ -211,6 +211,10 @@ function site_url( $path = '' ) {
 	return rtrim( WpEnv::$site_url, '/' ) . ( '' === $path ? '' : '/' . ltrim( (string) $path, '/' ) );
 }
 
+function wp_get_environment_type() {
+	return WpEnv::$environment_type;
+}
+
 function includes_url( $path = '' ) {
 	return rtrim( WpEnv::$site_url, '/' ) . '/wp-includes/' . ltrim( (string) $path, '/' );
 }

--- a/tests/Unit/BackgroundProcessStateTest.php
+++ b/tests/Unit/BackgroundProcessStateTest.php
@@ -563,7 +563,14 @@ final class BackgroundProcessStateTest extends UnitTestCase {
 			$request['args']['cookies']
 		);
 		self::assertSame( 0, $request['args']['redirection'] );
-		self::assertTrue( $request['args']['sslverify'] );
+		self::assertFalse( $request['args']['sslverify'] );
+	}
+
+	public function test_async_dispatch_allows_wordpress_ssl_filter_to_restore_verification(): void {
+		add_filter( 'https_local_ssl_verify', '__return_true' );
+		$args = ( new BackgroundStateProcess() )->post_args_for_test();
+
+		self::assertTrue( $args['sslverify'] );
 	}
 
 	public function test_async_dispatch_rejects_a_filtered_cross_origin_url_before_sending_credentials(): void {
@@ -764,7 +771,7 @@ final class BackgroundProcessStateTest extends UnitTestCase {
 		self::assertCount( 1, WpEnv::$remote_requests );
 		self::assertStringContainsString( 'action=wp_state_process', WpEnv::$remote_requests[0]['url'] );
 		self::assertStringContainsString( 'chain_id=', WpEnv::$remote_requests[0]['url'] );
-		self::assertTrue( WpEnv::$remote_requests[0]['args']['sslverify'] );
+		self::assertFalse( WpEnv::$remote_requests[0]['args']['sslverify'] );
 
 		WpEnv::$remote_response = new \WP_Error( 'loopback', 'Connection refused' );
 		self::assertTrue( $process->dispatch_via_background() );
@@ -814,7 +821,7 @@ final class BackgroundProcessStateTest extends UnitTestCase {
 		WpEnv::$remote_response = array( 'response' => array( 'code' => 403 ) );
 		self::assertFalse( $process->loopback_available_for_test() );
 		self::assertSame( 'no', WpEnv::$site_transients['wp_state_process_loopback_available'] );
-		self::assertTrue( WpEnv::$remote_requests[0]['args']['sslverify'] );
+		self::assertFalse( WpEnv::$remote_requests[0]['args']['sslverify'] );
 		self::assertStringContainsString( 'action=wp_state_process', WpEnv::$remote_requests[0]['url'] );
 		self::assertSame( 'nonce-wp_state_process', WpEnv::$remote_requests[0]['args']['body']['nonce'] );
 		self::assertSame( '1', WpEnv::$remote_requests[0]['args']['body']['simply_static_probe'] );

--- a/tests/Unit/BackgroundQueueResetTest.php
+++ b/tests/Unit/BackgroundQueueResetTest.php
@@ -125,9 +125,12 @@ namespace Simply_Static\Tests\Unit {
 			}
 
 			WpEnv::$site_transients = array(
-				'wp_archive_creation_job_process_lock'        => 'legacy-lock',
-				'wp_archive_creation_job_process_lock_site_7' => 'site-lock',
-				'wp_archive_creation_job_process_lock_site_8' => 'other-site-lock',
+				'wp_archive_creation_job_process_lock'                 => 'legacy-lock',
+				'wp_archive_creation_job_process_lock_site_7'          => 'site-lock',
+				'wp_archive_creation_job_process_lock_site_8'          => 'other-site-lock',
+				'wp_archive_creation_job_loopback_available'           => 'no',
+				'wp_archive_creation_job_loopback_available_site_7'    => 'no',
+				'wp_archive_creation_job_loopback_available_site_8'    => 'yes',
 			);
 			WpEnv::$site_options[ Plugin::SLUG . '_multisite_export_running' ] = 7;
 			$GLOBALS['simply_static_test_scheduled_hooks'] = array(
@@ -199,6 +202,9 @@ namespace Simply_Static\Tests\Unit {
 			self::assertSame( 'legacy-lock', WpEnv::$site_transients['wp_archive_creation_job_process_lock'] );
 			self::assertArrayNotHasKey( 'wp_archive_creation_job_process_lock_site_7', WpEnv::$site_transients );
 			self::assertSame( 'other-site-lock', WpEnv::$site_transients['wp_archive_creation_job_process_lock_site_8'] );
+			self::assertSame( 'no', WpEnv::$site_transients['wp_archive_creation_job_loopback_available'] );
+			self::assertArrayNotHasKey( 'wp_archive_creation_job_loopback_available_site_7', WpEnv::$site_transients );
+			self::assertSame( 'yes', WpEnv::$site_transients['wp_archive_creation_job_loopback_available_site_8'] );
 			self::assertArrayNotHasKey( Plugin::SLUG . '_multisite_export_running', WpEnv::$site_options );
 
 			self::assertArrayNotHasKey( 'wp_archive_creation_job_cron', $GLOBALS['simply_static_test_scheduled_hooks'] );
@@ -222,7 +228,9 @@ namespace Simply_Static\Tests\Unit {
 			$this->rest->reset_background_queue();
 
 			self::assertArrayNotHasKey( 'wp_archive_creation_job_process_lock', WpEnv::$site_transients );
+			self::assertArrayNotHasKey( 'wp_archive_creation_job_loopback_available', WpEnv::$site_transients );
 			self::assertSame( 'site-lock', WpEnv::$site_transients['wp_archive_creation_job_process_lock_site_7'] );
+			self::assertSame( 'no', WpEnv::$site_transients['wp_archive_creation_job_loopback_available_site_7'] );
 		}
 
 		public function test_reset_refuses_to_race_an_active_background_worker(): void {

--- a/tests/Unit/IntegrationSecurityTest.php
+++ b/tests/Unit/IntegrationSecurityTest.php
@@ -41,12 +41,12 @@ final class IntegrationSecurityTest extends UnitTestCase {
 		};
 	}
 
-	public function test_authenticated_requests_are_local_non_redirecting_and_tls_verified(): void {
+	public function test_authenticated_local_development_requests_are_non_redirecting(): void {
 		$this->integration->fetch( 'https://example.test/sitemap.xml' );
 
 		self::assertCount( 1, WpEnv::$remote_requests );
 		$args = WpEnv::$remote_requests[0]['args'];
-		self::assertTrue( $args['sslverify'] );
+		self::assertFalse( $args['sslverify'] );
 		self::assertSame( 0, $args['redirection'] );
 		self::assertSame( 'Basic ' . base64_encode( 'crawler:secret' ), $args['headers']['Authorization'] );
 	}

--- a/tests/Unit/PaginationCrawlerSecurityTest.php
+++ b/tests/Unit/PaginationCrawlerSecurityTest.php
@@ -37,7 +37,7 @@ final class PaginationCrawlerSecurityTest extends UnitTestCase {
 		self::assertSame( array( 'https://example.test/articles/page/2/' ), $urls );
 		self::assertCount( 2, WpEnv::$remote_requests );
 		foreach ( WpEnv::$remote_requests as $request ) {
-			self::assertTrue( $request['args']['sslverify'] );
+			self::assertFalse( $request['args']['sslverify'] );
 			self::assertSame( 0, $request['args']['redirection'] );
 			self::assertSame( 2 * 1024 * 1024 + 1, $request['args']['limit_response_size'] );
 			self::assertSame( 'Basic ' . base64_encode( 'crawler:secret' ), $request['args']['headers']['Authorization'] );

--- a/tests/Unit/SitemapCrawlerTest.php
+++ b/tests/Unit/SitemapCrawlerTest.php
@@ -255,10 +255,10 @@ namespace Simply_Static\Tests\Unit {
 			$get  = $this->requestsByMethod( 'GET' )[0];
 			self::assertSame( 2.5, $head['args']['timeout'] );
 			self::assertSame( 0, $head['args']['redirection'] );
-			self::assertTrue( $head['args']['sslverify'] );
+			self::assertFalse( $head['args']['sslverify'] );
 			self::assertSame( 2.5, $get['args']['timeout'] );
 			self::assertSame( 0, $get['args']['redirection'] );
-			self::assertTrue( $get['args']['sslverify'] );
+			self::assertFalse( $get['args']['sslverify'] );
 			self::assertSame( 65, $get['args']['limit_response_size'] );
 		}
 

--- a/tests/Unit/TextFileCrawlerTest.php
+++ b/tests/Unit/TextFileCrawlerTest.php
@@ -35,7 +35,7 @@ final class TextFileCrawlerTest extends UnitTestCase {
 		self::assertSame( 'https://example.test/llms.txt', $request['url'] );
 		self::assertSame( 5.0, $request['args']['timeout'] );
 		self::assertSame( 0, $request['args']['redirection'] );
-		self::assertTrue( $request['args']['sslverify'] );
+		self::assertFalse( $request['args']['sslverify'] );
 		self::assertSame( 4096, $request['args']['limit_response_size'] );
 	}
 

--- a/tests/Unit/UrlFetcherSecurityTest.php
+++ b/tests/Unit/UrlFetcherSecurityTest.php
@@ -27,14 +27,40 @@ final class UrlFetcherSecurityTest extends UnitTestCase {
 		Options::reinstance();
 	}
 
-	public function test_local_requests_verify_tls_and_receive_basic_auth(): void {
+	public function test_local_development_requests_skip_tls_verification_and_receive_basic_auth(): void {
 		Url_Fetcher::remote_get( 'https://example.test/page' );
 
 		self::assertCount( 1, WpEnv::$remote_requests );
 		$request = WpEnv::$remote_requests[0];
-		self::assertTrue( $request['args']['sslverify'] );
+		self::assertFalse( $request['args']['sslverify'] );
 		self::assertSame( 0, $request['args']['redirection'] );
 		self::assertSame( 'Basic ' . base64_encode( 'crawler:secret' ), $request['args']['headers']['Authorization'] );
+	}
+
+	public function test_production_requests_keep_tls_verification_enabled(): void {
+		WpEnv::$home_url = 'https://example.com';
+		WpEnv::$site_url = 'https://example.com';
+		Options::reinstance();
+
+		Url_Fetcher::remote_get( 'https://example.com/page' );
+
+		self::assertTrue( WpEnv::$remote_requests[0]['args']['sslverify'] );
+	}
+
+	public function test_ssl_filter_can_override_automatic_detection(): void {
+		add_filter( 'ss_remote_get_sslverify', '__return_true' );
+		Url_Fetcher::remote_get( 'https://example.test/page' );
+		self::assertTrue( WpEnv::$remote_requests[0]['args']['sslverify'] );
+
+		remove_filter( 'ss_remote_get_sslverify', '__return_true' );
+		WpEnv::$remote_requests = array();
+		WpEnv::$home_url        = 'https://example.com';
+		WpEnv::$site_url        = 'https://example.com';
+		Options::reinstance();
+		add_filter( 'ss_remote_get_sslverify', '__return_false' );
+
+		Url_Fetcher::remote_get( 'https://example.com/page' );
+		self::assertFalse( WpEnv::$remote_requests[0]['args']['sslverify'] );
 	}
 
 	public function test_external_and_alternate_port_requests_are_rejected_before_http(): void {

--- a/tests/Unit/UtilSecurityTest.php
+++ b/tests/Unit/UtilSecurityTest.php
@@ -73,6 +73,45 @@ final class UtilSecurityTest extends UnitTestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider localOriginProvider
+	 */
+	public function test_tls_verification_is_disabled_for_exact_local_origins( string $origin ): void {
+		WpEnv::$home_url = $origin;
+		WpEnv::$site_url = $origin;
+		Options::reinstance();
+
+		self::assertFalse( Util::should_verify_ssl( $origin . '/page' ) );
+	}
+
+	/** @return array<string,array{string}> */
+	public function localOriginProvider(): array {
+		return array(
+			'herd test domain'    => array( 'https://site.test' ),
+			'localhost subdomain' => array( 'https://site.localhost' ),
+			'ipv4 loopback'       => array( 'https://127.0.0.1' ),
+			'ipv6 loopback'       => array( 'https://[::1]' ),
+		);
+	}
+
+	public function test_tls_verification_stays_enabled_for_production_and_non_origin_urls(): void {
+		WpEnv::$home_url = 'https://example.com';
+		WpEnv::$site_url = 'https://example.com';
+		Options::reinstance();
+
+		self::assertTrue( Util::should_verify_ssl( 'https://example.com/page' ) );
+		self::assertTrue( Util::should_verify_ssl( 'https://external.test/page' ) );
+	}
+
+	public function test_explicit_local_environment_is_honored(): void {
+		WpEnv::$home_url         = 'https://example.com';
+		WpEnv::$site_url         = 'https://example.com';
+		WpEnv::$environment_type = 'local';
+		Options::reinstance();
+
+		self::assertFalse( Util::should_verify_ssl( 'https://example.com/page' ) );
+	}
+
 	public function test_basic_auth_is_only_returned_for_an_exact_local_origin(): void {
 		$expected = 'Basic ' . base64_encode( 'crawler:correct horse' );
 


### PR DESCRIPTION
Automatically disable TLS certificate verification only for exact WordPress origins in local environments, while retaining verification for production and cross-origin requests. Apply this policy consistently to URL fetching, crawlers, integrations, and async background requests while preserving existing filter overrides. Clear the cached loopback capability when resetting background queues, including multisite-scoped state. Tests: composer test (347 tests, 4490 assertions).