### PR TITLE
Ignore URL fragments in crawler queue

### DIFF
--- a/src/class-ss-util.php
+++ b/src/class-ss-util.php
@@ -2427,6 +2427,22 @@ class Util {
 	}
 
 	/**
+	 * Remove the fragment from a URL while preserving its query string.
+	 *
+	 * URL fragments are handled entirely by the browser and are never part of
+	 * the resource requested from the server.
+	 *
+	 * @param string $url URL from which to remove the fragment.
+	 *
+	 * @return string URL without its fragment.
+	 */
+	public static function remove_fragment( $url ) {
+		$fragment_position = strpos( $url, '#' );
+
+		return false === $fragment_position ? $url : substr( $url, 0, $fragment_position );
+	}
+
+	/**
 	 * Converts a textarea into an array w/ each line being an entry in the array
 	 *
 	 * @param string $textarea Textarea to convert

--- a/src/crawler/class-ss-crawler.php
+++ b/src/crawler/class-ss-crawler.php
@@ -107,15 +107,31 @@ abstract class Crawler {
 		foreach ( $batches as $batch ) {
 			\Simply_Static\Util::debug_log( sprintf( 'Processing batch of %d URLs for %s crawler', count( $batch ), $this->name ) );
 
-   foreach ( $batch as $url ) {
+			foreach ( $batch as $url ) {
+				if ( ! is_string( $url ) ) {
+					continue;
+				}
+
+				$discovered_url = $url;
+				$url            = trim( \Simply_Static\Util::remove_fragment( $url ) );
+
+				// Fragments are browser-side navigation state, not separate
+				// resources. A fragment-only value such as "#/page/2/" has no
+				// server URL to crawl, while an absolute URL with a fragment
+				// is queued once under its fragment-free page URL.
+				if ( '' === $url ) {
+					\Simply_Static\Util::debug_log( sprintf( 'Base crawler skipping fragment-only URL: %s', $discovered_url ) );
+					continue;
+				}
+
 				// Normalize URL to handle posts with URL-encoded post_name values
 				$url = \Simply_Static\Util::normalize_url( $url );
 
-   				// Skip excluded URLs to avoid adding to DB
-   				if ( \Simply_Static\Util::is_url_excluded( $url ) ) {
-   					\Simply_Static\Util::debug_log( sprintf( 'Base crawler skipping excluded URL: %s', $url ) );
-   					continue;
-   				}
+				// Skip excluded URLs to avoid adding to DB
+				if ( \Simply_Static\Util::is_url_excluded( $url ) ) {
+					\Simply_Static\Util::debug_log( sprintf( 'Base crawler skipping excluded URL: %s', $url ) );
+					continue;
+				}
 				// Skip selected custom 404 page from regular crawl/export
 				if ( ! empty( $exclude_url ) ) {
 					$normalized = untrailingslashit( $url );

--- a/tests/Unit/CrawlerQueueTest.php
+++ b/tests/Unit/CrawlerQueueTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use Simply_Static\Crawler\Crawler;
+use Simply_Static\Tests\Support\UnitTestCase;
+
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-plugin.php';
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-options.php';
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-util.php';
+require_once dirname( __DIR__, 2 ) . '/src/class-ss-query.php';
+require_once dirname( __DIR__, 2 ) . '/src/models/class-ss-model.php';
+require_once dirname( __DIR__, 2 ) . '/src/models/class-ss-page.php';
+require_once dirname( __DIR__, 2 ) . '/src/crawler/class-ss-crawler.php';
+
+final class CrawlerQueueWpdb {
+
+	/** @var array<int,array<string,mixed>> */
+	public $inserts = array();
+
+	/** @var int */
+	public $insert_id = 1;
+
+	public function get_blog_prefix(): string {
+		return 'wp_';
+	}
+
+	/** @return null */
+	public function get_row( string $query, $output = null ) {
+		return null;
+	}
+
+	/**
+	 * @param array<string,mixed> $data
+	 * @return int
+	 */
+	public function insert( string $table, array $data ): int {
+		$this->inserts[] = array(
+			'table' => $table,
+			'data'  => $data,
+		);
+		++$this->insert_id;
+
+		return 1;
+	}
+}
+
+final class FragmentCrawler extends Crawler {
+
+	/** @var string[] */
+	private $urls;
+
+	/** @param string[] $urls */
+	public function __construct( array $urls ) {
+		$this->name = 'Fragment test';
+		$this->urls = $urls;
+	}
+
+	/** @return string[] */
+	public function detect(): array {
+		return $this->urls;
+	}
+}
+
+final class CrawlerQueueTest extends UnitTestCase {
+
+	/** @var CrawlerQueueWpdb */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->wpdb       = new CrawlerQueueWpdb();
+		$GLOBALS['wpdb'] = $this->wpdb;
+	}
+
+	public function test_fragment_routes_are_not_added_as_separate_pages(): void {
+		$crawler = new FragmentCrawler(
+			array(
+				'#',
+				'#/',
+				'#/page/2/',
+				'https://example.test/#/page/3/',
+				'https://example.test/article/#section',
+				'https://example.test/actual/',
+			)
+		);
+
+		$added = $crawler->add_urls_to_queue();
+
+		self::assertSame( 3, $added );
+		self::assertSame(
+			array(
+				'https://example.test/',
+				'https://example.test/article/',
+				'https://example.test/actual/',
+			),
+			array_column( array_column( $this->wpdb->inserts, 'data' ), 'url' )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Strip browser-only URL fragments before base crawler URLs are normalized and queued.
- Skip fragment-only routes while preserving query strings on crawlable URLs.
- Add regression coverage for fragment-only routes, absolute URLs with fragments, and normal URLs.

## Testing

- vendor/bin/phpunit --configuration phpunit.xml.dist (352 tests, 4507 assertions)