### PR TITLE
Prepare release 3.8.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jamstack, performance, security, static site generator
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag:  3.8.4
+Stable tag:  3.8.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -274,6 +274,15 @@ Settings - Configure your static site export options
 Diagnostics - Check your WordPress environment for compatibility
 
 == Changelog ==
+
+= 3.8.5 =
+
+* Requeued assets during update exports when their generated paths change
+* Improved support for self-signed certificates in local development environments
+* Skipped empty WordPress core asset placeholders during export discovery
+* Prevented empty generated files from entering transfers and deploy manifests
+* Ignored URL fragments when queueing crawler results
+* Fixed MySQL 8 role-grant warnings in Diagnostics
 
 = 3.8.4 =
 

--- a/simply-static.php
+++ b/simply-static.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Simply Static
  * Plugin URI:        https://simplystatic.com
  * Description:       A static site generator to create fast and secure static versions of your WordPress website.
- * Version:           3.8.4
+ * Version:           3.8.5
  * Requires at least:  6.2
  * Author:            Patrick Posner
  * Author URI:        https://patrickposner.com
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'SIMPLY_STATIC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLY_STATIC_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'SIMPLY_STATIC_VERSION', '3.8.4' );
+define( 'SIMPLY_STATIC_VERSION', '3.8.5' );
 
 // Check PHP version.
 if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {

--- a/src/admin/package-lock.json
+++ b/src/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplystatic-settings",
-      "version": "3.8.4",
+      "version": "3.8.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "react-data-table-component": "^8.5.0",

--- a/src/admin/package.json
+++ b/src/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/tests/Support/wordpress-stubs.php
+++ b/tests/Support/wordpress-stubs.php
@@ -13,6 +13,7 @@ defined( 'MINUTE_IN_SECONDS' ) || define( 'MINUTE_IN_SECONDS', 60 );
 defined( 'HOUR_IN_SECONDS' ) || define( 'HOUR_IN_SECONDS', 3600 );
 defined( 'DAY_IN_SECONDS' ) || define( 'DAY_IN_SECONDS', 86400 );
 defined( 'ARRAY_A' ) || define( 'ARRAY_A', 'ARRAY_A' );
+defined( 'ARRAY_N' ) || define( 'ARRAY_N', 'ARRAY_N' );
 defined( 'SIMPLY_STATIC_PATH' ) || define( 'SIMPLY_STATIC_PATH', dirname( __DIR__, 2 ) . '/' );
 defined( 'SIMPLY_STATIC_URL' ) || define( 'SIMPLY_STATIC_URL', 'https://example.test/wp-content/plugins/simply-static' );
 defined( 'SIMPLY_STATIC_VERSION' ) || define( 'SIMPLY_STATIC_VERSION', 'test' );

--- a/tests/Unit/BootstrapCompatibilityTest.php
+++ b/tests/Unit/BootstrapCompatibilityTest.php
@@ -55,6 +55,7 @@ namespace Simply_Static\Tests\Unit {
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.2' ) );
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.3' ) );
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.4' ) );
+			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.5' ) );
 		}
 
 		public function test_outdated_active_pro_is_left_active_but_all_runtime_hooks_are_blocked(): void {
@@ -102,20 +103,20 @@ namespace Simply_Static\Tests\Unit {
 			$package   = json_decode( (string) file_get_contents( $root . '/src/admin/package.json' ), true );
 			$lock      = json_decode( (string) file_get_contents( $root . '/src/admin/package-lock.json' ), true );
 
-			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.4$/m', $bootstrap );
+			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.5$/m', $bootstrap );
 			self::assertMatchesRegularExpression( '/^ \* Requires at least:\s+6\.2$/m', $bootstrap );
-			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.4' );", $bootstrap );
+			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.5' );", $bootstrap );
 			self::assertStringContainsString( "version_compare( get_bloginfo( 'version' ), '6.2', '<' )", $bootstrap );
 			self::assertStringContainsString( 'Simply Static requires WordPress 6.2 or higher.', $bootstrap );
 			self::assertStringContainsString( "require_once SIMPLY_STATIC_PATH . 'src/class-ss-pro-compatibility.php';", $bootstrap );
 			self::assertStringContainsString( "add_action( 'plugins_loaded', array( 'Simply_Static\\Pro_Compatibility', 'enforce' ), 1 );", $bootstrap );
 			self::assertStringNotContainsString( 'deactivate_plugins( $pro_basename', $bootstrap );
-			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.4$/m', $readme );
+			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.5$/m', $readme );
 			self::assertMatchesRegularExpression( '/^Requires at least:\s+6\.2$/m', $readme );
-			self::assertStringContainsString( '= 3.8.4 =', $readme );
-			self::assertSame( '3.8.4', $package['version'] ?? null );
-			self::assertSame( '3.8.4', $lock['version'] ?? null );
-			self::assertSame( '3.8.4', $lock['packages']['']['version'] ?? null );
+			self::assertStringContainsString( '= 3.8.5 =', $readme );
+			self::assertSame( '3.8.5', $package['version'] ?? null );
+			self::assertSame( '3.8.5', $lock['version'] ?? null );
+			self::assertSame( '3.8.5', $lock['packages']['']['version'] ?? null );
 		}
 
 		private function registerProRuntimeHooks(): void {

--- a/tests/Unit/SqlPermissionsTest.php
+++ b/tests/Unit/SqlPermissionsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simply_Static\Tests\Unit;
+
+use ReflectionProperty;
+use Simply_Static\Sql_Permissions;
+use Simply_Static\Tests\Support\UnitTestCase;
+
+final class SqlPermissionsWpdb {
+
+	/** @var string */
+	public $dbname = 'wordpress';
+
+	/** @var array<int,array{string}> */
+	public $rows = array();
+
+	/** @return array<int,array{string}> */
+	public function get_results( string $query, $output = null ): array {
+		return $this->rows;
+	}
+}
+
+final class SqlPermissionsTest extends UnitTestCase {
+
+	/** @var mixed */
+	private $previous_wpdb;
+
+	/** @var SqlPermissionsWpdb */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->requireSource( 'src/class-ss-sql-permissions.php' );
+
+		$this->previous_wpdb = $GLOBALS['wpdb'] ?? null;
+		$this->wpdb          = new SqlPermissionsWpdb();
+		$GLOBALS['wpdb']     = $this->wpdb;
+		$this->resetInstance();
+	}
+
+	protected function tearDown(): void {
+		$this->resetInstance();
+		$GLOBALS['wpdb'] = $this->previous_wpdb;
+
+		parent::tearDown();
+	}
+
+	public function test_role_grants_are_skipped_while_direct_permissions_are_detected(): void {
+		$this->wpdb->rows = array(
+			array( 'GRANT `rds_superuser_role`@`%` TO `admin`@`%`' ),
+			array( 'GRANT SELECT, INSERT ON `wordpress`.* TO `admin`@`%`' ),
+		);
+
+		$permissions = Sql_Permissions::instance();
+
+		self::assertTrue( $permissions->can( 'select' ) );
+		self::assertTrue( $permissions->can( 'insert' ) );
+		self::assertFalse( $permissions->can( 'update' ) );
+	}
+
+	private function resetInstance(): void {
+		$property = new ReflectionProperty( Sql_Permissions::class, 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+}


### PR DESCRIPTION
## Summary

- bump Simply Static to 3.8.5 across plugin and admin metadata
- document the fixes included since 3.8.4
- add regression coverage for MySQL 8 role-grant rows in SQL diagnostics

## Validation

- `composer test` (353 tests, 4511 assertions)
- admin JavaScript tests (51 tests), lint, and production build
- installer production build
- `./scripts/validate-release-version.sh 3.8.5`
- release ZIP build and checksum verification