### PR TITLE
Fix release asset upload repository context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,4 +172,5 @@ jobs:
           gh release upload "$RELEASE_TAG" \
             build/release/simply-static.zip \
             build/release/simply-static.zip.sha256 \
+            --repo "$GITHUB_REPOSITORY" \
             --clobber


### PR DESCRIPTION
## Summary

- pass the repository explicitly to `gh release upload`
- allow the publish job to attach assets without checking out a Git repository

## Context

The 3.8.5 workflow deployed successfully to WordPress.org but the final asset attachment failed because the publish job intentionally has no checkout. The verified 3.8.5 assets were attached manually.