### PR TITLE
Prepare release 3.8.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jamstack, performance, security, static site generator
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag:  3.8.5
+Stable tag:  3.8.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -274,6 +274,12 @@ Settings - Configure your static site export options
 Diagnostics - Check your WordPress environment for compatibility
 
 == Changelog ==
+
+= 3.8.6 =
+
+* Restored safe, clickable ZIP download and deployment destination links in the activity log
+* Fixed activity log, export log, and multisite site data REST responses
+* Fixed GitHub release asset uploads when the publish job has no repository checkout
 
 = 3.8.5 =
 

--- a/simply-static.php
+++ b/simply-static.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Simply Static
  * Plugin URI:        https://simplystatic.com
  * Description:       A static site generator to create fast and secure static versions of your WordPress website.
- * Version:           3.8.5
+ * Version:           3.8.6
  * Requires at least:  6.2
  * Author:            Patrick Posner
  * Author URI:        https://patrickposner.com
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'SIMPLY_STATIC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLY_STATIC_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'SIMPLY_STATIC_VERSION', '3.8.5' );
+define( 'SIMPLY_STATIC_VERSION', '3.8.6' );
 
 // Check PHP version.
 if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {

--- a/src/admin/package-lock.json
+++ b/src/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplystatic-settings",
-      "version": "3.8.5",
+      "version": "3.8.6",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "react-data-table-component": "^8.5.0",

--- a/src/admin/package.json
+++ b/src/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/tests/Unit/BootstrapCompatibilityTest.php
+++ b/tests/Unit/BootstrapCompatibilityTest.php
@@ -56,6 +56,7 @@ namespace Simply_Static\Tests\Unit {
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.3' ) );
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.4' ) );
 			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.5' ) );
+			self::assertSame( '2.5.0', Pro_Compatibility::required_pro_version( '3.8.6' ) );
 		}
 
 		public function test_outdated_active_pro_is_left_active_but_all_runtime_hooks_are_blocked(): void {
@@ -103,20 +104,20 @@ namespace Simply_Static\Tests\Unit {
 			$package   = json_decode( (string) file_get_contents( $root . '/src/admin/package.json' ), true );
 			$lock      = json_decode( (string) file_get_contents( $root . '/src/admin/package-lock.json' ), true );
 
-			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.5$/m', $bootstrap );
+			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.6$/m', $bootstrap );
 			self::assertMatchesRegularExpression( '/^ \* Requires at least:\s+6\.2$/m', $bootstrap );
-			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.5' );", $bootstrap );
+			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.6' );", $bootstrap );
 			self::assertStringContainsString( "version_compare( get_bloginfo( 'version' ), '6.2', '<' )", $bootstrap );
 			self::assertStringContainsString( 'Simply Static requires WordPress 6.2 or higher.', $bootstrap );
 			self::assertStringContainsString( "require_once SIMPLY_STATIC_PATH . 'src/class-ss-pro-compatibility.php';", $bootstrap );
 			self::assertStringContainsString( "add_action( 'plugins_loaded', array( 'Simply_Static\\Pro_Compatibility', 'enforce' ), 1 );", $bootstrap );
 			self::assertStringNotContainsString( 'deactivate_plugins( $pro_basename', $bootstrap );
-			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.5$/m', $readme );
+			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.6$/m', $readme );
 			self::assertMatchesRegularExpression( '/^Requires at least:\s+6\.2$/m', $readme );
-			self::assertStringContainsString( '= 3.8.5 =', $readme );
-			self::assertSame( '3.8.5', $package['version'] ?? null );
-			self::assertSame( '3.8.5', $lock['version'] ?? null );
-			self::assertSame( '3.8.5', $lock['packages']['']['version'] ?? null );
+			self::assertStringContainsString( '= 3.8.6 =', $readme );
+			self::assertSame( '3.8.6', $package['version'] ?? null );
+			self::assertSame( '3.8.6', $lock['version'] ?? null );
+			self::assertSame( '3.8.6', $lock['packages']['']['version'] ?? null );
 		}
 
 		private function registerProRuntimeHooks(): void {


### PR DESCRIPTION
## Summary

- bump Simply Static to 3.8.6
- add the 3.8.6 changelog
- align release metadata and compatibility tests

## Validation

- release workflow passed
- branch test workflow passed
- WordPress.org deployment completed
- GitHub ZIP and checksum attached