### PR TITLE
Fix JSON errors after inline exports

### DIFF
--- a/src/background/class-ss-background-process.php
+++ b/src/background/class-ss-background-process.php
@@ -111,6 +111,13 @@ abstract class Background_Process extends Async_Request {
 	protected $inline_dispatch_pending = false;
 
 	/**
+	 * Whether response finalization was attempted before inline work began.
+	 *
+	 * @var bool
+	 */
+	protected $inline_response_finish_attempted = false;
+
+	/**
 	 * Value written to the current process lock by this PHP process.
 	 *
 	 * @var string|null
@@ -449,6 +456,11 @@ abstract class Background_Process extends Async_Request {
 					return;
 				}
 
+				// PHP shutdown callbacks still run before some web servers finish the
+				// client response. Close it explicitly so a long inline export cannot
+				// turn an otherwise valid REST response into a gateway/JSON error.
+				$process->finish_http_response_for_inline_processing();
+
 				// Access the protected handle() method via Closure binding.
 				$handler = \Closure::bind( function () {
 					$this->handle();
@@ -469,6 +481,38 @@ abstract class Background_Process extends Async_Request {
 		} );
 
 		return true;
+	}
+
+	/**
+	 * Close the client connection before running a long inline worker.
+	 *
+	 * The method is intentionally isolated so hosts without a supported server
+	 * API keep the existing behavior and test processes can override it without
+	 * attempting to finish their own output stream.
+	 *
+	 * @return void
+	 */
+	protected function finish_http_response_for_inline_processing() {
+		if ( $this->inline_response_finish_attempted ) {
+			return;
+		}
+
+		$this->inline_response_finish_attempted = true;
+
+		// Keep processing after the web server closes the client connection.
+		ignore_user_abort( true );
+
+		// Release a PHP session lock before the worker starts making loopback or
+		// polling requests for the same logged-in browser session.
+		if ( function_exists( 'session_status' ) && PHP_SESSION_ACTIVE === session_status() ) {
+			session_write_close();
+		}
+
+		if ( function_exists( 'fastcgi_finish_request' ) ) {
+			fastcgi_finish_request();
+		} elseif ( function_exists( 'litespeed_finish_request' ) ) {
+			litespeed_finish_request();
+		}
 	}
 
 	/**

--- a/src/class-ss-url-fetcher.php
+++ b/src/class-ss-url-fetcher.php
@@ -80,6 +80,11 @@ class Url_Fetcher {
 		$original_url = $static_page->url;
 		$url          = $original_url;
 
+		// Single and incremental exports reuse Page records. Start each new fetch
+		// with a clean error state so a successful retry does not keep reporting a
+		// failure from an earlier export or attempt.
+		$static_page->clear_error_message();
+
 		// Windows support.
 		$url = Util::normalize_slashes( $url );
 

--- a/src/models/class-ss-page.php
+++ b/src/models/class-ss-page.php
@@ -167,6 +167,17 @@ class Page extends Model {
 		}
 	}
 
+	/**
+	 * Clear errors left by an earlier processing attempt.
+	 *
+	 * Page records are retained for single and incremental exports. A later
+	 * successful fetch should therefore replace, rather than continue to show,
+	 * an error from an older attempt.
+	 */
+	public function clear_error_message() {
+		$this->error_message = null;
+	}
+
 	protected function has_error_message( $message ) {
 		if ( ! $this->error_message ) {
 			return false;

--- a/tests/Unit/BackgroundProcessStateTest.php
+++ b/tests/Unit/BackgroundProcessStateTest.php
@@ -233,6 +233,9 @@ final class BackgroundInlineContinuationProcess extends BackgroundStateProcess {
 	/** @var int */
 	public $handle_calls = 0;
 
+	/** @var int */
+	public $finish_response_calls = 0;
+
 	public function is_processing() {
 		return false;
 	}
@@ -250,6 +253,14 @@ final class BackgroundInlineContinuationProcess extends BackgroundStateProcess {
 	protected function handle() {
 		++$this->handle_calls;
 		parent::dispatch_inline();
+	}
+
+	protected function finish_http_response_for_inline_processing() {
+		$was_attempted = $this->inline_response_finish_attempted;
+		parent::finish_http_response_for_inline_processing();
+		if ( ! $was_attempted && $this->inline_response_finish_attempted ) {
+			++$this->finish_response_calls;
+		}
 	}
 
 	public function run_shutdown_handler( int $index ): void {
@@ -789,7 +800,14 @@ final class BackgroundProcessStateTest extends UnitTestCase {
 		$process->run_shutdown_handler( 0 );
 
 		self::assertSame( 1, $process->handle_calls );
+		self::assertSame( 1, $process->finish_response_calls );
 		self::assertCount( 2, $process->shutdown_handlers );
+
+		$process->run_shutdown_handler( 1 );
+
+		self::assertSame( 2, $process->handle_calls );
+		self::assertSame( 1, $process->finish_response_calls );
+		self::assertCount( 3, $process->shutdown_handlers );
 	}
 
 	public function test_inline_fallback_does_not_continue_a_paused_queue(): void {
@@ -800,6 +818,7 @@ final class BackgroundProcessStateTest extends UnitTestCase {
 		$process->run_shutdown_handler( 0 );
 
 		self::assertSame( 0, $process->handle_calls );
+		self::assertSame( 0, $process->finish_response_calls );
 		self::assertCount( 1, $process->shutdown_handlers );
 	}
 

--- a/tests/Unit/PageModelHelpersTest.php
+++ b/tests/Unit/PageModelHelpersTest.php
@@ -100,6 +100,10 @@ final class PageModelHelpersTest extends UnitTestCase {
 
 		self::assertSame( 'Timed out; Invalid response', $page->error_message );
 		self::assertSame( 'Skipped query string; Saved redirect', $page->status_message );
+
+		$page->clear_error_message();
+
+		self::assertNull( $page->error_message );
 	}
 
 	/**

--- a/tests/Unit/UrlFetcherSecurityTest.php
+++ b/tests/Unit/UrlFetcherSecurityTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Simply_Static\Tests\Unit;
 
 use Simply_Static\Options;
+use Simply_Static\Page;
 use Simply_Static\Tests\Support\UnitTestCase;
 use Simply_Static\Tests\Support\WpTestEnvironment as WpEnv;
 use Simply_Static\Url_Fetcher;
@@ -17,6 +18,10 @@ final class UrlFetcherSecurityTest extends UnitTestCase {
 		$this->requireSource( 'src/class-ss-options.php' );
 		$this->requireSource( 'src/class-ss-phpuri.php' );
 		$this->requireSource( 'src/class-ss-util.php' );
+		$this->requireSource( 'src/class-ss-query.php' );
+		$this->requireSource( 'src/models/class-ss-model.php' );
+		$this->requireSource( 'src/models/class-ss-page.php' );
+		$this->requireSource( 'src/handlers/class-ss-page-handler.php' );
 		$this->requireSource( 'src/class-ss-url-fetcher.php' );
 
 		WpEnv::$options['simply-static'] = array(
@@ -81,5 +86,38 @@ final class UrlFetcherSecurityTest extends UnitTestCase {
 		Url_Fetcher::remote_get( 'https://example.test/page' );
 
 		self::assertArrayNotHasKey( 'Authorization', WpEnv::$remote_requests[0]['args']['headers'] );
+	}
+
+	public function test_successful_retry_clears_an_error_from_an_earlier_attempt(): void {
+		$GLOBALS['wpdb'] = new class() {
+			public function get_blog_prefix(): string {
+				return 'wp_';
+			}
+
+			public function update( string $table, array $data, array $where ): int {
+				return 1;
+			}
+		};
+
+		WpEnv::$remote_response = array(
+			'response' => array( 'code' => 301 ),
+			'headers'  => array(
+				'content-type' => 'text/html',
+				'location'     => 'https://example.test/',
+			),
+			'body'     => '',
+		);
+
+		$page = Page::initialize(
+			array(
+				'id'            => 17,
+				'url'           => 'https://example.test/old-redirect/',
+				'error_message' => 'Unable to write temporary file',
+			)
+		);
+
+		self::assertTrue( Url_Fetcher::instance()->fetch( $page ) );
+		self::assertNull( $page->error_message );
+		self::assertSame( 301, $page->http_status_code );
 	}
 }


### PR DESCRIPTION
Closes the client response before inline background processing starts, preventing successful long-running exports from surfacing gateway responses as invalid JSON in the Command Center. Releases PHP session locks and finalizes FastCGI or LiteSpeed requests once, while preserving existing behavior on unsupported hosts. Clears retained page errors when a new fetch attempt begins so successful retries do not show stale temporary-file failures. Adds regression coverage for inline continuations and retried redirect fetches; the full PHPUnit suite passes with 357 tests and 4,541 assertions.