### PR TITLE
Replace bare origin hosts in inline scripts

### DIFF
--- a/src/class-ss-url-extractor.php
+++ b/src/class-ss-url-extractor.php
@@ -1898,6 +1898,10 @@ class Url_Extractor {
 		// Also replace JSON-encoded URLs
 		$text = preg_replace( '/' . Util::json_escaped_origin_url_pattern() . $escaped_destination_path_guard . '/i', addcslashes( untrailingslashit( $convert_to ), '/' ), $text );
 
+		// Replace a bare origin hostname when it is stored as a complete string value.
+		// Google Site Kit uses this form for its linker domains configuration.
+		$text = $this->replace_bare_origin_host_in_script( $text );
+
 		// Replace URLs in sourceURL and sourceMappingURL comments (used for debugging)
 		// Handles both //# and //@ formats (the latter is deprecated but still used)
 		$text = preg_replace( '/(\/\/[#@]\s*(?:sourceURL|sourceMappingURL)\s*=\s*)(https?:)?\/\/' . Util::origin_host_pattern() . $destination_path_guard . '/i', '$1' . $convert_to, $text );
@@ -1906,6 +1910,49 @@ class Url_Extractor {
 		$text = $this->replace_runtime_local_paths_in_script( $text );
 
 		return $text;
+	}
+
+	/**
+	 * Replace a quoted, hostname-only origin value in inline JavaScript.
+	 *
+	 * Full URLs are handled above, but some scripts store the current host without
+	 * a protocol. Only exact quoted values are replaced so text containing the
+	 * hostname, email addresses, and similarly prefixed domains remain unchanged.
+	 *
+	 * @param string $text JavaScript or JSON content.
+	 *
+	 * @return string
+	 */
+	private function replace_bare_origin_host_in_script( $text ) {
+		if ( 'absolute' !== $this->options->get( 'destination_url_type' ) ) {
+			return $text;
+		}
+
+		$origin_parts      = function_exists( 'wp_parse_url' ) ? wp_parse_url( Util::origin_url() ) : parse_url( Util::origin_url() );
+		$destination_parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $this->options->get_destination_url() ) : parse_url( $this->options->get_destination_url() );
+
+		if ( ! is_array( $origin_parts ) || ! is_array( $destination_parts ) || empty( $origin_parts['host'] ) || empty( $destination_parts['host'] ) ) {
+			return $text;
+		}
+
+		$origin_host      = (string) $origin_parts['host'];
+		$destination_host = (string) $destination_parts['host'];
+
+		if ( 0 === strcasecmp( $origin_host, $destination_host ) ) {
+			return $text;
+		}
+
+		$pattern = '/(["\'])' . preg_quote( $origin_host, '/' ) . '\\1/i';
+
+		$replaced = preg_replace_callback(
+			$pattern,
+			function ( $matches ) use ( $destination_host ) {
+				return $matches[1] . $destination_host . $matches[1];
+			},
+			$text
+		);
+
+		return is_string( $replaced ) ? $replaced : $text;
 	}
 
 	/**

--- a/tests/Unit/UrlExtractorTest.php
+++ b/tests/Unit/UrlExtractorTest.php
@@ -189,6 +189,41 @@ final class UrlExtractorTest extends UnitTestCase {
 		self::assertStringContainsString( 'https://external.test/a.jpg', $xml_extractor->get_body() );
 	}
 
+	public function test_replaces_bare_origin_host_in_inline_scripts(): void {
+		$html = '<script id="google_gtagjs-js-after">'
+			. 'gtag("set","linker",{"domains":["example.test"]});'
+			. "const alternate = 'example.test';"
+			. 'const external = "external.test";'
+			. 'const prefixed = "www.example.test";'
+			. 'const suffixed = "example.test.invalid";'
+			. 'const email = "user@example.test";'
+			. '</script>';
+		$extractor = $this->extractor( 'html', $html );
+
+		$extractor->extract_and_update_urls();
+		$body = $extractor->get_body();
+
+		self::assertStringContainsString( '"domains":["static.example.test"]', $body );
+		self::assertStringContainsString( "const alternate = 'static.example.test';", $body );
+		self::assertStringContainsString( 'const external = "external.test";', $body );
+		self::assertStringContainsString( 'const prefixed = "www.example.test";', $body );
+		self::assertStringContainsString( 'const suffixed = "example.test.invalid";', $body );
+		self::assertStringContainsString( 'const email = "user@example.test";', $body );
+	}
+
+	public function test_preserves_bare_origin_host_for_non_absolute_exports(): void {
+		WpEnv::$options['simply-static']['destination_url_type'] = 'relative';
+		WpEnv::$options['simply-static']['relative_path'] = '/';
+		Options::reinstance();
+
+		$html = '<script>gtag("set","linker",{"domains":["example.test"]});</script>';
+		$extractor = $this->extractor( 'html', $html );
+
+		$extractor->extract_and_update_urls();
+
+		self::assertStringContainsString( '"domains":["example.test"]', $extractor->get_body() );
+	}
+
 	public function test_relative_and_offline_destination_modes_produce_local_paths(): void {
 		WpEnv::$options['simply-static']['destination_url_type'] = 'relative';
 		WpEnv::$options['simply-static']['relative_path'] = '/';


### PR DESCRIPTION
## Summary
- replace quoted hostname-only origin values in inline JavaScript for absolute exports
- cover Google Site Kit linker domain output without affecting external, prefixed, suffixed, or email values
- preserve existing behavior for relative and offline exports

## Tests
- `vendor/bin/phpunit --configuration phpunit.xml.dist` (359 tests, 4548 assertions)
- `php -l src/class-ss-url-extractor.php`
- `php -l tests/Unit/UrlExtractorTest.php`
- `git diff --check`