### PR TITLE
Prepare release 3.8.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jamstack, performance, security, static site generator
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag:  3.8.8
+Stable tag:  3.8.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -52,7 +52,7 @@ Your WordPress site stays private and secure. Your static site is what visitors 
 The free version is perfect for simple static exports, but if you need advanced deployment, automation, and powerful features, check out our premium solutions.
 
 = Simply Static Pro - For Developers & Agencies =
-$129/year per site | $399/year unlimited sites
+$99/year per site
 Deploy to any platform. Automate everything. Keep 100% of your profit margins.
 
 * Deploy to GitHub, Netlify, Cloudflare Pages, AWS S3, BunnyCDN, SFTP
@@ -71,7 +71,7 @@ Perfect for developers self-hosting client sites, agencies managing infrastructu
 [Get Simply Static Pro](https://simplystatic.com/simply-static-pro/)
 
 = Simply Static Studio - For Businesses & Content Creators =
-From $19/month
+$19/month per site
 All-in-one managed WordPress hosting. Zero maintenance. Maximum security.
 
 * Fully managed WordPress hosting
@@ -85,7 +85,7 @@ All-in-one managed WordPress hosting. Zero maintenance. Maximum security.
 
 Perfect for businesses running 1-5 websites, content creators who want simplicity, and anyone who values convenience over control.
 
-[Try Studio Free for 7 Days](https://simplystatic.com/simply-static-studio/)
+[Try Studio Free for 14 Days](https://simplystatic.com/simply-static-studio/)
 
 = Trusted by 40,000+ Users Worldwide =
 * 1,400,000+ plugin downloads
@@ -201,8 +201,8 @@ Yes! The core plugin is 100% free and open source. It provides everything you ne
 Simply Static Pro and Studio are optional premium products for advanced features like automated deployment, forms, search, and managed hosting.
 = What's the difference between the free plugin, Pro, and Studio? =
 Free: Generate static sites, export as ZIP or to local directory. Perfect for testing and simple exports.
-Pro ($129-399/year): Advanced deployment, automation, forms, search, WP-CLI. For developers and agencies self-hosting.
-Studio (from $19/month): All-in-one managed hosting. We handle WordPress, static hosting, backups, SSL, everything. For businesses who want zero maintenance.
+Pro ($99/year per site): Advanced deployment, automation, forms, search, WP-CLI. For developers and agencies self-hosting.
+Studio ($19/month per site): All-in-one managed hosting. We handle WordPress, static hosting, backups, SSL, everything. For businesses who want zero maintenance.
 See detailed comparison
 = Can I use the free version for production sites? =
 Yes, but you'll need to manually upload the ZIP file to your hosting provider each time you update your site.
@@ -274,6 +274,13 @@ Settings - Configure your static site export options
 Diagnostics - Check your WordPress environment for compatibility
 
 == Changelog ==
+
+= 3.8.9 =
+
+* Fixed bare origin host replacement in inline scripts, including Google Site Kit linker domains
+* Fixed script and comment restoration for filtered or fragment HTML
+* Improved Static Studio deployment notice visibility and refreshed the Studio promo
+* Updated Simply Static Pro and Static Studio pricing and trial information
 
 = 3.8.8 =
 

--- a/simply-static.php
+++ b/simply-static.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Simply Static
  * Plugin URI:        https://simplystatic.com
  * Description:       A static site generator to create fast and secure static versions of your WordPress website.
- * Version:           3.8.8
+ * Version:           3.8.9
  * Requires at least:  6.2
  * Author:            Patrick Posner
  * Author URI:        https://patrickposner.com
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'SIMPLY_STATIC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLY_STATIC_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'SIMPLY_STATIC_VERSION', '3.8.8' );
+define( 'SIMPLY_STATIC_VERSION', '3.8.9' );
 
 // Check PHP version.
 if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {

--- a/src/admin/package-lock.json
+++ b/src/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplystatic-settings",
-      "version": "3.8.8",
+      "version": "3.8.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "react-data-table-component": "^8.8.0",

--- a/src/admin/package.json
+++ b/src/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplystatic-settings",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/tests/Unit/BootstrapCompatibilityTest.php
+++ b/tests/Unit/BootstrapCompatibilityTest.php
@@ -105,20 +105,20 @@ namespace Simply_Static\Tests\Unit {
 			$package   = json_decode( (string) file_get_contents( $root . '/src/admin/package.json' ), true );
 			$lock      = json_decode( (string) file_get_contents( $root . '/src/admin/package-lock.json' ), true );
 
-			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.8$/m', $bootstrap );
+			self::assertMatchesRegularExpression( '/^ \* Version:\s+3\.8\.9$/m', $bootstrap );
 			self::assertMatchesRegularExpression( '/^ \* Requires at least:\s+6\.2$/m', $bootstrap );
-			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.8' );", $bootstrap );
+			self::assertStringContainsString( "define( 'SIMPLY_STATIC_VERSION', '3.8.9' );", $bootstrap );
 			self::assertStringContainsString( "version_compare( get_bloginfo( 'version' ), '6.2', '<' )", $bootstrap );
 			self::assertStringContainsString( 'Simply Static requires WordPress 6.2 or higher.', $bootstrap );
 			self::assertStringContainsString( "require_once SIMPLY_STATIC_PATH . 'src/class-ss-pro-compatibility.php';", $bootstrap );
 			self::assertStringContainsString( "add_action( 'plugins_loaded', array( 'Simply_Static\\Pro_Compatibility', 'enforce' ), 1 );", $bootstrap );
 			self::assertStringNotContainsString( 'deactivate_plugins( $pro_basename', $bootstrap );
-			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.8$/m', $readme );
+			self::assertMatchesRegularExpression( '/^Stable tag:\s+3\.8\.9$/m', $readme );
 			self::assertMatchesRegularExpression( '/^Requires at least:\s+6\.2$/m', $readme );
-			self::assertStringContainsString( '= 3.8.8 =', $readme );
-			self::assertSame( '3.8.8', $package['version'] ?? null );
-			self::assertSame( '3.8.8', $lock['version'] ?? null );
-			self::assertSame( '3.8.8', $lock['packages']['']['version'] ?? null );
+			self::assertStringContainsString( '= 3.8.9 =', $readme );
+			self::assertSame( '3.8.9', $package['version'] ?? null );
+			self::assertSame( '3.8.9', $lock['version'] ?? null );
+			self::assertSame( '3.8.9', $lock['packages']['']['version'] ?? null );
 		}
 
 		private function registerProRuntimeHooks(): void {


### PR DESCRIPTION
## Summary

- bump Simply Static to 3.8.9 across release metadata
- add the 3.8.9 changelog for changes since 3.8.8
- update Simply Static Pro pricing and the Static Studio price/trial copy

## Validation

- `composer test` — 361 tests, 4558 assertions
- `npm test -- --runInBand` — 57 tests
- `npm run lint`
- rebuilt both React applications with no bundle drift
- `./scripts/validate-release-version.sh 3.8.9`
- built and checksum-verified the release ZIP
- production npm and Composer security audits report no vulnerabilities